### PR TITLE
Remove unnecesasary "open-iconic" CSS reference

### DIFF
--- a/Crypter.Web/wwwroot/css/app.css
+++ b/Crypter.Web/wwwroot/css/app.css
@@ -1,6 +1,4 @@
-﻿@import url('open-iconic/font/css/open-iconic-bootstrap.min.css');
-
-html, body {
+﻿html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 


### PR DESCRIPTION
We do not need to import `open-iconic-bootstrap.min.css`.  This was included in the .NET 5 migration instructions, but is not necessary for us.