### PR TITLE
Make sessions more persistent with re-authentication prompt

### DIFF
--- a/Crypter.API/Controllers/UserController.cs
+++ b/Crypter.API/Controllers/UserController.cs
@@ -139,8 +139,8 @@ namespace Crypter.API.Controllers
             {
                new Claim(ClaimTypes.NameIdentifier, user.Id.ToString())
             }),
-            Audience = "crypter.dev",
-            Issuer = "crypter.dev/api",
+            Audience = "www.crypter.dev",
+            Issuer = "www.crypter.dev/api",
             Expires = DateTime.UtcNow.AddHours(1),
             SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(TokenSecretKey), SecurityAlgorithms.HmacSha256Signature)
          };
@@ -153,7 +153,7 @@ namespace Crypter.API.Controllers
          BackgroundJob.Enqueue(() => UserService.UpdateLastLoginTime(user.Id, DateTime.UtcNow));
 
          return new OkObjectResult(
-             new UserAuthenticateResponse(user.Id, tokenString, userX25519KeyPair?.PrivateKey, userEd25519KeyPair?.PrivateKey, userX25519KeyPair.ClientIV, userEd25519KeyPair.ClientIV)
+             new UserAuthenticateResponse(user.Id, tokenString, userX25519KeyPair?.PrivateKey, userEd25519KeyPair?.PrivateKey, userX25519KeyPair?.ClientIV, userEd25519KeyPair?.ClientIV)
          );
       }
 

--- a/Crypter.API/Startup.cs
+++ b/Crypter.API/Startup.cs
@@ -105,8 +105,8 @@ namespace CrypterAPI
             options.SaveToken = true;
             options.TokenValidationParameters = new TokenValidationParameters
             {
-               ValidAudience = "crypter.dev",
-               ValidIssuer = "crypter.dev/api",
+               ValidAudience = "www.crypter.dev",
+               ValidIssuer = "www.crypter.dev/api",
                ValidateIssuerSigningKey = true,
                IssuerSigningKey = new SymmetricSecurityKey(tokenSigningKey),
                ValidateLifetime = true,

--- a/Crypter.Contracts/Enum/PublicKeyType.cs
+++ b/Crypter.Contracts/Enum/PublicKeyType.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * Copyright (C) 2021 Crypter File Transfer
+ * 
+ * This file is part of the Crypter file transfer project.
+ * 
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ * 
+ * Contact the current copyright holder to discuss commerical license options.
+ */
+
+namespace Crypter.Contracts.Enum
+{
+   public enum PublicKeyType
+   {
+      X25519,
+      Ed25519
+   }
+}

--- a/Crypter.Contracts/Requests/User/AuthenticateUserRequest.cs
+++ b/Crypter.Contracts/Requests/User/AuthenticateUserRequest.cs
@@ -32,12 +32,14 @@ namespace Crypter.Contracts.Requests
    {
       public string Username { get; set; }
       public string Password { get; set; }
+      public bool ProvideRefreshToken { get; set; }
 
       [JsonConstructor]
-      public AuthenticateUserRequest(string username, string password)
+      public AuthenticateUserRequest(string username, string password, bool provideRefreshToken)
       {
          Username = username;
          Password = password;
+         ProvideRefreshToken = provideRefreshToken;
       }
    }
 }

--- a/Crypter.CryptoLib/UserFunctions.cs
+++ b/Crypter.CryptoLib/UserFunctions.cs
@@ -32,15 +32,16 @@ namespace Crypter.CryptoLib
    public static class UserFunctions
    {
       /// <summary>
-      /// Digest a user's login information.
+      /// Digest the user's credentials.
       /// </summary>
-      /// <param name="username"></param>
+      /// <param name="username">Username will be lowercased within the method.</param>
       /// <param name="password"></param>
       /// <returns>Array of 64 bytes.</returns>
       /// <remarks>
-      /// The result of this method is used as the user's password during authentication requests.
+      /// The result of this method gets used as the user's password during authentication requests.
+      /// The reason for doing this is to keep the user's real password a secret from even our own API.
       /// </remarks>
-      public static byte[] DigestUserCredentials(string username, string password)
+      public static byte[] DeriveAuthenticationPasswordFromUserCredentials(string username, string password)
       {
          var digestor = new Crypto.SHA(SHAFunction.SHA512);
          digestor.BlockUpdate(Encoding.UTF8.GetBytes(password));
@@ -49,12 +50,12 @@ namespace Crypter.CryptoLib
       }
 
       /// <summary>
-      /// Derive a symmetric encryption key from the user's login information
+      /// Use the user's credentials to create a symmetric key.
       /// </summary>
-      /// <param name="username"></param>
+      /// <param name="username">Username will be lowercased within the method.</param>
       /// <param name="password"></param>
       /// <returns>Array of 32 bytes.</returns>
-      public static byte[] DeriveSymmetricCryptoParamsFromUserDetails(string username, string password)
+      public static byte[] DeriveSymmetricKeyFromUserCredentials(string username, string password)
       {
          var keyDigestor = new Crypto.SHA(SHAFunction.SHA256);
          keyDigestor.BlockUpdate(Encoding.UTF8.GetBytes(username.ToLower()));

--- a/Crypter.Test/CryptoLib_Tests/UserFunctions_Tests.cs
+++ b/Crypter.Test/CryptoLib_Tests/UserFunctions_Tests.cs
@@ -55,7 +55,7 @@ namespace Crypter.Test.CryptoLib_Tests
             0xb7, 0xa1, 0xcd, 0xda, 0x9c, 0x42, 0xc8, 0xe2
          };
 
-         var digestedCredentials = UserFunctions.DigestUserCredentials(username, password);
+         var digestedCredentials = UserFunctions.DeriveAuthenticationPasswordFromUserCredentials(username, password);
          Assert.AreEqual(knownDigest, digestedCredentials);
       }
 
@@ -66,8 +66,8 @@ namespace Crypter.Test.CryptoLib_Tests
          var usernameUppercase = "USERNAME";
          var password = "P@ssw0rd?";
 
-         var lowercaseDigest = UserFunctions.DigestUserCredentials(usernameLowercase, password);
-         var uppercaseDigest = UserFunctions.DigestUserCredentials(usernameUppercase, password);
+         var lowercaseDigest = UserFunctions.DeriveAuthenticationPasswordFromUserCredentials(usernameLowercase, password);
+         var uppercaseDigest = UserFunctions.DeriveAuthenticationPasswordFromUserCredentials(usernameUppercase, password);
          Assert.AreEqual(lowercaseDigest, uppercaseDigest);
       }
 
@@ -78,8 +78,8 @@ namespace Crypter.Test.CryptoLib_Tests
          var passwordLowercase = "password";
          var passwordUppercase = "PASSWORD";
 
-         var lowercaseDigest = UserFunctions.DigestUserCredentials(username, passwordLowercase);
-         var uppercaseDigest = UserFunctions.DigestUserCredentials(username, passwordUppercase);
+         var lowercaseDigest = UserFunctions.DeriveAuthenticationPasswordFromUserCredentials(username, passwordLowercase);
+         var uppercaseDigest = UserFunctions.DeriveAuthenticationPasswordFromUserCredentials(username, passwordUppercase);
          Assert.AreNotEqual(lowercaseDigest, uppercaseDigest);
       }
 
@@ -97,7 +97,7 @@ namespace Crypter.Test.CryptoLib_Tests
             0xfb, 0x91, 0x38, 0x41, 0x2d, 0xa4, 0xde, 0x52
          };
 
-         var key = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username, password);
+         var key = UserFunctions.DeriveSymmetricKeyFromUserCredentials(username, password);
          Assert.AreEqual(knownKey, key);
       }
 
@@ -108,8 +108,8 @@ namespace Crypter.Test.CryptoLib_Tests
          var usernameUppercase = "GIMLI";
          var password = "TheDwarf";
 
-         var lowercaseKey = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(usernameLowercase, password);
-         var uppercaseKey = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(usernameUppercase, password);
+         var lowercaseKey = UserFunctions.DeriveSymmetricKeyFromUserCredentials(usernameLowercase, password);
+         var uppercaseKey = UserFunctions.DeriveSymmetricKeyFromUserCredentials(usernameUppercase, password);
          Assert.AreEqual(lowercaseKey, uppercaseKey);
       }
 
@@ -120,8 +120,8 @@ namespace Crypter.Test.CryptoLib_Tests
          var lowercasePassword = "son_of_arathorn";
          var uppercasePassword = "SON_OF_ARATHORN";
 
-         var lowercaseKey = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username, lowercasePassword);
-         var uppercaseKey = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username, uppercasePassword);
+         var lowercaseKey = UserFunctions.DeriveSymmetricKeyFromUserCredentials(username, lowercasePassword);
+         var uppercaseKey = UserFunctions.DeriveSymmetricKeyFromUserCredentials(username, uppercasePassword);
          Assert.AreNotEqual(lowercaseKey, uppercaseKey);
       }
    }

--- a/Crypter.Web/Models/Forms/LoginModel.cs
+++ b/Crypter.Web/Models/Forms/LoginModel.cs
@@ -24,16 +24,12 @@
  * Contact the current copyright holder to discuss commerical license options.
  */
 
-using System.ComponentModel.DataAnnotations;
-
-namespace Crypter.Web.Models
+namespace Crypter.Web.Models.Forms
 {
-    public class Login
-    {
-        [Required(ErrorMessage = "Username is required")]
-        public string Username { get; set; }
-
-        [Required(ErrorMessage = "Password is required")]
-        public string Password { get; set; }
-    }
+   public class LoginModel
+   {
+      public string Username { get; set; }
+      public string Password { get; set; }
+      public bool RememberMe { get; set; }
+   }
 }

--- a/Crypter.Web/Models/Forms/UserRegistrationModel.cs
+++ b/Crypter.Web/Models/Forms/UserRegistrationModel.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * Copyright (C) 2021 Crypter File Transfer
+ * 
+ * This file is part of the Crypter file transfer project.
+ * 
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ * 
+ * Contact the current copyright holder to discuss commerical license options.
+ */
+
+namespace Crypter.Web.Models.Forms
+{
+   public class UserRegistrationModel
+   {
+      public string Username { get; set; }
+      public string Password { get; set; }
+      public string PasswordConfirm { get; set; }
+      public string EmailAddress { get; set; }
+   }
+}

--- a/Crypter.Web/Models/LocalStorage/EncryptedPrivateKey.cs
+++ b/Crypter.Web/Models/LocalStorage/EncryptedPrivateKey.cs
@@ -24,13 +24,17 @@
  * Contact the current copyright holder to discuss commerical license options.
  */
 
-namespace Crypter.Web.Models.Forms
+namespace Crypter.Web.Models.LocalStorage
 {
-   public class UserRegistration
+   public class EncryptedPrivateKey
    {
-      public string Username { get; set; }
-      public string Password { get; set; }
-      public string PasswordConfirm { get; set; }
-      public string EmailAddress { get; set; }
+      public string Key { get; set; }
+      public string IV { get; set; }
+
+      public EncryptedPrivateKey(string key, string iv)
+      {
+         Key = key;
+         IV = iv;
+      }
    }
 }

--- a/Crypter.Web/Models/LocalStorage/UserSession.cs
+++ b/Crypter.Web/Models/LocalStorage/UserSession.cs
@@ -26,19 +26,21 @@
 
 using System;
 
-namespace Crypter.Web.Models
+namespace Crypter.Web.Models.LocalStorage
 {
    public class UserSession
    {
       public Guid UserId { get; set; }
       public string Username { get; set; }
-      public string Token { get; set; }
+      public string EncryptedAuthToken { get; set; }
+      public string AuthTokenIV { get; set; }
 
-      public UserSession(Guid userId, string username, string token)
+      public UserSession(Guid userId, string username, string encryptedAuthToken, string authTokenIV)
       {
          UserId = userId;
          Username = username;
-         Token = token;
+         EncryptedAuthToken = encryptedAuthToken;
+         AuthTokenIV = authTokenIV;
       }
    }
 }

--- a/Crypter.Web/Pages/UserSettings.razor.cs
+++ b/Crypter.Web/Pages/UserSettings.razor.cs
@@ -26,6 +26,7 @@
 
 using Crypter.Contracts.Enum;
 using Crypter.Contracts.Requests;
+using Crypter.Web.Models.LocalStorage;
 using Crypter.Web.Services;
 using Crypter.Web.Services.API;
 using Microsoft.AspNetCore.Components;
@@ -166,7 +167,7 @@ namespace Crypter.Web.Pages
             Console.WriteLine("fail");
             return;
          }
-         byte[] digestedPassword = CryptoLib.UserFunctions.DigestUserCredentials(Username, CurrentPasswordForContactInfo);
+         byte[] digestedPassword = CryptoLib.UserFunctions.DeriveAuthenticationPasswordFromUserCredentials(Username, CurrentPasswordForContactInfo);
          string digestedPasswordBase64 = Convert.ToBase64String(digestedPassword);
 
          var request = new UpdateContactInfoRequest(EditedEmail, digestedPasswordBase64);
@@ -280,8 +281,11 @@ namespace Crypter.Web.Pages
 
          EnableTransferNotifications = EditedEnableTransferNotifications = userAccountInfo.EnableTransferNotifications;
 
-         X25519PrivateKey = "Encrypted";
-         Ed25519PrivateKey = "Encrypted";
+         var encryptedX25519PrivateKey = (await LocalStorage.GetItemAsync<EncryptedPrivateKey>(StoredObjectType.EncryptedX25519PrivateKey)).Key;
+         var encryptedEd25519PrivateKey = (await LocalStorage.GetItemAsync<EncryptedPrivateKey>(StoredObjectType.EncryptedEd25519PrivateKey)).Key;
+
+         X25519PrivateKey = encryptedX25519PrivateKey;
+         Ed25519PrivateKey = encryptedEd25519PrivateKey;
          ProfileUrl = $"{NavigationManager.BaseUri}user/profile/{Username}";
       }
 

--- a/Crypter.Web/Program.cs
+++ b/Crypter.Web/Program.cs
@@ -59,7 +59,8 @@ namespace Crypter.Web
             .AddScoped<ITransferApiService, TransferApiService>()
             .AddScoped<IUserApiService, UserApiService>()
             .AddScoped<IMetricsApiService, MetricsApiService>()
-            .AddScoped<IUserKeysService, UserKeysService>();
+            .AddScoped<IUserKeysService, UserKeysService>()
+            .AddScoped<ISimpleEncryptionService, SimpleEncryptionService>();
 
          var host = builder.Build();
 

--- a/Crypter.Web/Services/AuthenticationService.cs
+++ b/Crypter.Web/Services/AuthenticationService.cs
@@ -24,11 +24,11 @@
  * Contact the current copyright holder to discuss commerical license options.
  */
 
+using Crypter.Contracts.Enum;
 using Crypter.Contracts.Requests;
 using Crypter.Contracts.Responses;
-using Crypter.Web.Models;
+using Crypter.Web.Models.LocalStorage;
 using Crypter.Web.Services.API;
-using Microsoft.AspNetCore.Components;
 using System;
 using System.Net;
 using System.Text;
@@ -38,126 +38,200 @@ namespace Crypter.Web.Services
 {
    public interface IAuthenticationService
    {
-      Task<bool> Login(string username, string plaintextPassword, string digestedPassword);
-      Task Logout();
+      Task<bool> LoginAsync(string username, string password, bool trustDevice);
+      Task<bool> ReauthenticateAsync(string password);
+      Task LogoutAsync();
    }
 
    public class AuthenticationService : IAuthenticationService
    {
-      private readonly NavigationManager NavigationManager;
-      private readonly IUserApiService UserApiService;
-      private readonly IUserKeysService UserKeysService;
-      private readonly ILocalStorageService LocalStorage;
+      private readonly IUserApiService _userApiService;
+      private readonly IUserKeysService _userKeysService;
+      private readonly ILocalStorageService _localStorageService;
+      private readonly ISimpleEncryptionService _simpleEncryptionService;
 
-      public AuthenticationService(
-          NavigationManager navigationManager,
-          IUserApiService userApiService,
-          IUserKeysService userKeysService,
-          ILocalStorageService localStorage
-      )
+      public AuthenticationService(IUserApiService userApiService, IUserKeysService userKeysService, ILocalStorageService localStorageService, ISimpleEncryptionService simpleEncryptionService)
       {
-         NavigationManager = navigationManager;
-         UserApiService = userApiService;
-         UserKeysService = userKeysService;
-         LocalStorage = localStorage;
+         _userApiService = userApiService;
+         _userKeysService = userKeysService;
+         _localStorageService = localStorageService;
+         _simpleEncryptionService = simpleEncryptionService;
       }
 
-      public async Task<bool> Login(string username, string plaintextPassword, string digestedPassword)
+      public async Task<bool> LoginAsync(string username, string password, bool trustDevice)
       {
-         var loginRequest = new AuthenticateUserRequest(username, digestedPassword);
-         var (httpStatus, authResponse) = await UserApiService.AuthenticateUserAsync(loginRequest);
-         if (httpStatus != HttpStatusCode.OK)
+         var (authSuccess, authResponse) = await SendAuthenticationRequestAsync(username, password, trustDevice);
+         if (!authSuccess)
          {
             return false;
          }
 
-         var userSession = new UserSession(authResponse.Id, username, authResponse.Token);
-         await LocalStorage.SetItem(StoredObjectType.UserSession, userSession, StorageLocation.InMemory);
+         var userPreferredStorageLocation = trustDevice
+            ? StorageLocation.LocalStorage
+            : StorageLocation.SessionStorage;
 
-         await InitializeUserKeys(authResponse, username, plaintextPassword);
+         var userSymmetricKey = _userKeysService.GetUserSymmetricKey(username, password);
 
+         await CacheSessionInfoAsync(authResponse, username, userSymmetricKey, userPreferredStorageLocation);
+         await HandleUserKeys(authResponse, userSymmetricKey, userPreferredStorageLocation);
          return true;
       }
 
-      public async Task Logout()
+      public async Task<bool> ReauthenticateAsync(string password)
       {
-         await LocalStorage.Dispose();
-         NavigationManager.NavigateTo("/");
+         var userSessionInfo = await _localStorageService.GetItemAsync<UserSession>(StoredObjectType.UserSession);
+         var userSymmetricKey = _userKeysService.GetUserSymmetricKey(userSessionInfo.Username, password);
+         var userEncryptedX25519 = await _localStorageService.GetItemAsync<EncryptedPrivateKey>(StoredObjectType.EncryptedX25519PrivateKey);
+         var userEncryptedEd25519 = await _localStorageService.GetItemAsync<EncryptedPrivateKey>(StoredObjectType.EncryptedEd25519PrivateKey);
+
+         var (decryptTokenSuccess, token) = DecryptLocalAuthToken(userSymmetricKey, userSessionInfo);
+         var (decryptX25519Success, x25519) = DecryptLocalPrivateKey(userSymmetricKey, userEncryptedX25519);
+         var (decryptEd25519Success, ed25519) = DecryptLocalPrivateKey(userSymmetricKey, userEncryptedEd25519);
+
+         if (decryptTokenSuccess && decryptX25519Success && decryptEd25519Success)
+         {
+            await _localStorageService.SetItemAsync(StoredObjectType.AuthToken, token, StorageLocation.InMemory);
+            await _localStorageService.SetItemAsync(StoredObjectType.PlaintextX25519PrivateKey, x25519, StorageLocation.InMemory);
+            await _localStorageService.SetItemAsync(StoredObjectType.PlaintextEd25519PrivateKey, ed25519, StorageLocation.InMemory);
+
+            // TODO - Test the token by hitting the API
+            // If the API rejects the token, perform a full-fledged login since we already have the users credentials
+
+            return true;
+         }
+         return false;
       }
 
-      private async Task InitializeUserKeys(UserAuthenticateResponse response, string username, string password)
+      public async Task LogoutAsync()
       {
-         if (string.IsNullOrEmpty(response.EncryptedX25519PrivateKey))
+         await _localStorageService.DisposeAsync();
+      }
+
+      private async Task CacheSessionInfoAsync(UserAuthenticateResponse authResponse, string username, byte[] userSymmetricKey, StorageLocation storageLocation)
+      {
+         var (encryptedToken, tokenIV) = _simpleEncryptionService.Encrypt(userSymmetricKey, authResponse.Token);
+         var base64EncryptedToken = Convert.ToBase64String(encryptedToken);
+         var base64TokenIV = Convert.ToBase64String(tokenIV);
+
+         var sessionInfo = new UserSession(authResponse.Id, username, base64EncryptedToken, base64TokenIV);
+         await _localStorageService.SetItemAsync(StoredObjectType.UserSession, sessionInfo, storageLocation);
+
+         // The plaintext JWT should only be stored InMemory
+         await _localStorageService.SetItemAsync(StoredObjectType.AuthToken, authResponse.Token, StorageLocation.InMemory);
+      }
+
+      private async Task<(bool success, UserAuthenticateResponse response)> SendAuthenticationRequestAsync(string username, string password, bool requestRefreshToken)
+      {
+         byte[] digestedPassword = CryptoLib.UserFunctions.DeriveAuthenticationPasswordFromUserCredentials(username, password);
+         string digestedPasswordBase64 = Convert.ToBase64String(digestedPassword);
+
+         var loginRequest = new AuthenticateUserRequest(username, digestedPasswordBase64, requestRefreshToken);
+         var (httpStatus, authResponse) = await _userApiService.AuthenticateUserAsync(loginRequest);
+         return (httpStatus == HttpStatusCode.OK, authResponse);
+      }
+
+      private async Task HandleUserKeys(UserAuthenticateResponse authResponse, byte[] userSymmetricKey, StorageLocation storageLocation)
+      {
+         // Handle X25519
+         if (string.IsNullOrEmpty(authResponse.EncryptedX25519PrivateKey))
          {
-            await HandleMissingX25519Keys(response.Id, username, password);
+            var (privateKey, publicKey) = _userKeysService.NewX25519KeyPair();
+            var (encryptedPrivateKey, iv) = _simpleEncryptionService.Encrypt(userSymmetricKey, privateKey);
+            await UploadKeyPairAsync(encryptedPrivateKey, publicKey, iv, PublicKeyType.X25519);
+
+            await _localStorageService.SetItemAsync(StoredObjectType.PlaintextX25519PrivateKey, privateKey, StorageLocation.InMemory);
+            await CacheEncryptedPrivateKey(encryptedPrivateKey, iv, StoredObjectType.EncryptedX25519PrivateKey, storageLocation);
          }
          else
          {
-            var decodedX25519Key = Convert.FromBase64String(response.EncryptedX25519PrivateKey);
-            await LocalStorage.SetItem(StoredObjectType.EncryptedX25519PrivateKey, decodedX25519Key, StorageLocation.InMemory);
+            var iv = Convert.FromBase64String(authResponse.X25519IV);
+            var encryptedPrivateKey = Convert.FromBase64String(authResponse.EncryptedX25519PrivateKey);
+            var plaintextPrivateKey = _simpleEncryptionService.DecryptToString(userSymmetricKey, iv, encryptedPrivateKey);
 
-            var decodedIV = Convert.FromBase64String(response.X25519IV);
-            var decryptedKey = UserKeysService.DecryptPrivateKey(username, password, decodedX25519Key, decodedIV);
-            await LocalStorage.SetItem(StoredObjectType.PlaintextX25519PrivateKey, decryptedKey, StorageLocation.InMemory);
+            await _localStorageService.SetItemAsync(StoredObjectType.PlaintextX25519PrivateKey, plaintextPrivateKey, StorageLocation.InMemory);
+            await CacheEncryptedPrivateKey(encryptedPrivateKey, iv, StoredObjectType.EncryptedX25519PrivateKey, storageLocation);
          }
 
-         if (string.IsNullOrEmpty(response.EncryptedEd25519PrivateKey))
+         // Handle Ed25519
+         if (string.IsNullOrEmpty(authResponse.EncryptedEd25519PrivateKey))
          {
-            await HandleMissingEd25519Keys(response.Id, username, password);
+            var (privateKey, publicKey) = _userKeysService.NewEd25519KeyPair();
+            var (encryptedPrivateKey, iv) = _simpleEncryptionService.Encrypt(userSymmetricKey, privateKey);
+            await UploadKeyPairAsync(encryptedPrivateKey, publicKey, iv, PublicKeyType.Ed25519);
+
+            await _localStorageService.SetItemAsync(StoredObjectType.PlaintextEd25519PrivateKey, privateKey, StorageLocation.InMemory);
+            await CacheEncryptedPrivateKey(encryptedPrivateKey, iv, StoredObjectType.EncryptedEd25519PrivateKey, storageLocation);
          }
          else
          {
-            var decodedEd25519Key = Convert.FromBase64String(response.EncryptedEd25519PrivateKey);
-            await LocalStorage.SetItem(StoredObjectType.EncryptedEd25519PrivateKey, decodedEd25519Key, StorageLocation.InMemory);
+            var iv = Convert.FromBase64String(authResponse.Ed25519IV);
+            var encryptedPrivateKey = Convert.FromBase64String(authResponse.EncryptedEd25519PrivateKey);
+            var plaintextPrivateKey = _simpleEncryptionService.DecryptToString(userSymmetricKey, iv, encryptedPrivateKey);
 
-            var decodedIV = Convert.FromBase64String(response.Ed25519IV);
-            var decryptedKey = UserKeysService.DecryptPrivateKey(username, password, decodedEd25519Key, decodedIV);
-            await LocalStorage.SetItem(StoredObjectType.PlaintextEd25519PrivateKey, decryptedKey, StorageLocation.InMemory);
+            await _localStorageService.SetItemAsync(StoredObjectType.PlaintextEd25519PrivateKey, plaintextPrivateKey, StorageLocation.InMemory);
+            await CacheEncryptedPrivateKey(encryptedPrivateKey, iv, StoredObjectType.EncryptedEd25519PrivateKey, storageLocation);
          }
       }
 
-      /// <summary>
-      /// Generate and upload a new X25519 key pair.
-      /// </summary>
-      /// <param name="userId"></param>
-      /// <param name="username"></param>
-      /// <param name="password"></param>
-      private async Task HandleMissingX25519Keys(Guid userId, string username, string password)
+      private async Task UploadKeyPairAsync(byte[] encryptedPrivateKey, string publicKey, byte[] iv, PublicKeyType keyType)
       {
-         var (encryptedPrivateKey, publicKey, iv) = UserKeysService.GenerateNewX25519KeyPair(username, password);
+         var base64PublicKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(publicKey));
+         var base64EncryptedPrivateKey = Convert.ToBase64String(encryptedPrivateKey);
+         var base64IV = Convert.ToBase64String(iv);
 
-         var encodedPublicKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(publicKey));
-         var encodedEncryptedPrivateKey = Convert.ToBase64String(encryptedPrivateKey);
-         var encodedIV = Convert.ToBase64String(iv);
-
-         var request = new UpdateKeysRequest(encodedEncryptedPrivateKey, encodedPublicKey, encodedIV);
-         await UserApiService.InsertUserX25519KeysAsync(request);
-         await LocalStorage.SetItem(StoredObjectType.EncryptedX25519PrivateKey, encryptedPrivateKey, StorageLocation.InMemory);
-
-         var decryptedKey = UserKeysService.DecryptPrivateKey(username, password, encryptedPrivateKey, iv);
-         await LocalStorage.SetItem(StoredObjectType.PlaintextX25519PrivateKey, decryptedKey, StorageLocation.InMemory);
+         var request = new UpdateKeysRequest(base64EncryptedPrivateKey, base64PublicKey, base64IV);
+         switch (keyType)
+         {
+            case PublicKeyType.X25519:
+               await _userApiService.InsertUserX25519KeysAsync(request);
+               break;
+            case PublicKeyType.Ed25519:
+               await _userApiService.InsertUserEd25519KeysAsync(request);
+               break;
+            default:
+               throw new ArgumentException("Invalid key type");
+         }
       }
 
-      /// <summary>
-      /// Generate and upload a new Ed25519 key pair.
-      /// </summary>
-      /// <param name="userId"></param>
-      /// <param name="username"></param>
-      /// <param name="password"></param>
-      private async Task HandleMissingEd25519Keys(Guid userId, string username, string password)
+      private async Task CacheEncryptedPrivateKey(byte[] encryptedPrivateKey, byte[] iv, StoredObjectType objectType, StorageLocation storageLocation)
       {
-         var (encryptedPrivateKey, publicKey, iv) = UserKeysService.GenerateNewEd25519KeyPair(username, password);
+         var base64EncryptedPrivateKey = Convert.ToBase64String(encryptedPrivateKey);
+         var base64IV = Convert.ToBase64String(iv);
+         var storageModel = new EncryptedPrivateKey(base64EncryptedPrivateKey, base64IV);
+         await _localStorageService.SetItemAsync(objectType, storageModel, storageLocation);
+      }
 
-         var encodedPublicKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(publicKey));
-         var encodedEncryptedPrivateKey = Convert.ToBase64String(encryptedPrivateKey);
-         var encodedIV = Convert.ToBase64String(iv);
+      private (bool success, string token) DecryptLocalAuthToken(byte[] userSymmetricKey, UserSession sessionInfo)
+      {
+         var encryptedToken = Convert.FromBase64String(sessionInfo.EncryptedAuthToken);
+         var iv = Convert.FromBase64String(sessionInfo.AuthTokenIV);
 
-         var request = new UpdateKeysRequest(encodedEncryptedPrivateKey, encodedPublicKey, encodedIV);
-         await UserApiService.InsertUserEd25519KeysAsync(request);
-         await LocalStorage.SetItem(StoredObjectType.EncryptedEd25519PrivateKey, encryptedPrivateKey, StorageLocation.InMemory);
+         try
+         {
+            var plaintextAuthToken = _simpleEncryptionService.DecryptToString(userSymmetricKey, iv, encryptedToken);
+            return (true, plaintextAuthToken);
+         }
+         catch (Exception)
+         {
+            return (false, null);
+         }
+      }
 
-         var decryptedKey = UserKeysService.DecryptPrivateKey(username, password, encryptedPrivateKey, iv);
-         await LocalStorage.SetItem(StoredObjectType.PlaintextEd25519PrivateKey, decryptedKey, StorageLocation.InMemory);
+      private (bool success, string privateKey) DecryptLocalPrivateKey(byte[] userSymmetricKey, EncryptedPrivateKey encryptionInfo)
+      {
+         var encryptedKey = Convert.FromBase64String(encryptionInfo.Key);
+         var iv = Convert.FromBase64String(encryptionInfo.IV);
+
+         try
+         {
+            var plaintextKey = _simpleEncryptionService.DecryptToString(userSymmetricKey, iv, encryptedKey);
+            System.Console.WriteLine(plaintextKey);
+            return (true, plaintextKey);
+         }
+         catch (Exception)
+         {
+            return (false, null);
+         }
       }
    }
 }

--- a/Crypter.Web/Services/SimpleEncryptionService.cs
+++ b/Crypter.Web/Services/SimpleEncryptionService.cs
@@ -1,0 +1,91 @@
+﻿/*
+ * Copyright (C) 2021 Crypter File Transfer
+ * 
+ * This file is part of the Crypter file transfer project.
+ * 
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ * 
+ * Contact the current copyright holder to discuss commerical license options.
+ */
+
+using Crypter.CryptoLib.Crypto;
+using System.Text;
+
+namespace Crypter.Web.Services
+{
+   public interface ISimpleEncryptionService
+   {
+      byte[] Encrypt(byte[] key, byte[] iv, byte[] plaintext);
+      byte[] Encrypt(byte[] key, byte[] iv, string plaintext);
+      (byte[] ciphertext, byte[] iv) Encrypt(byte[] key, byte[] plaintext);
+      (byte[] ciphertext, byte[] iv) Encrypt(byte[] key, string plaintext);
+      byte[] Decrypt(byte[] key, byte[] iv, byte[] ciphertext);
+      string DecryptToString(byte[] key, byte[] iv, byte[] ciphertext);
+   }
+
+   public class SimpleEncryptionService : ISimpleEncryptionService
+   {
+      public byte[] Encrypt(byte[] key, byte[] iv, byte[] plaintext)
+      {
+         var encrypter = new AES();
+         encrypter.Initialize(key, iv, true);
+         return encrypter.ProcessFinal(plaintext);
+      }
+
+      public (byte[] ciphertext, byte[] iv) Encrypt(byte[] key, byte[] plaintext)
+      {
+         var iv = AES.GenerateIV();
+
+         var encrypter = new AES();
+         encrypter.Initialize(key, iv, true);
+         return (encrypter.ProcessFinal(plaintext), iv);
+      }
+
+      public byte[] Encrypt(byte[] key, byte[] iv, string plaintext)
+      {
+         var encrypter = new AES();
+         encrypter.Initialize(key, iv, true);
+         return encrypter.ProcessFinal(Encoding.UTF8.GetBytes(plaintext));
+      }
+
+      public (byte[] ciphertext, byte[] iv) Encrypt(byte[] key, string plaintext)
+      {
+         var iv = AES.GenerateIV();
+
+         var encrypter = new AES();
+         encrypter.Initialize(key, iv, true);
+         return (encrypter.ProcessFinal(Encoding.UTF8.GetBytes(plaintext)), iv);
+      }
+
+      public byte[] Decrypt(byte[] key, byte[] iv, byte[] ciphertext)
+      {
+         var decrypter = new AES();
+         decrypter.Initialize(key, iv, false);
+         return decrypter.ProcessFinal(ciphertext);
+      }
+
+      public string DecryptToString(byte[] key, byte[] iv, byte[] ciphertext)
+      {
+         var decrypter = new AES();
+         decrypter.Initialize(key, iv, false);
+         var plaintext = decrypter.ProcessFinal(ciphertext);
+         return Encoding.UTF8.GetString(plaintext);
+      }
+   }
+}

--- a/Crypter.Web/Services/UserKeysService.cs
+++ b/Crypter.Web/Services/UserKeysService.cs
@@ -24,9 +24,6 @@
  * Contact the current copyright holder to discuss commerical license options.
  */
 
-using System;
-using System.Text;
-
 namespace Crypter.Web.Services
 {
    public interface IUserKeysService
@@ -34,70 +31,54 @@ namespace Crypter.Web.Services
       /// <summary>
       /// Generate a new X25519 key pair.
       /// </summary>
-      /// <param name="userId"></param>
-      /// <param name="username"></param>
-      /// <param name="password"></param>
-      /// <returns>Encrypted private key and plaintext public key in PEM format</returns>
-      (byte[] encryptedPrivateKey, string publicKey, byte [] iv) GenerateNewX25519KeyPair(string username, string password);
+      /// <returns>Private and public keys in PEM format</returns>
+      (string privateKey, string publicKey) NewX25519KeyPair();
 
       /// <summary>
       /// Generate a new Ed25519 key pair.
       /// </summary>
-      /// <param name="userId"></param>
-      /// <param name="username"></param>
-      /// <param name="password"></param>
-      /// <returns>Encrypted private key and plaintext public key in PEM format</returns>
-      public (byte[] encryptedPrivateKey, string publicKey, byte[] iv) GenerateNewEd25519KeyPair(string username, string password);
+      /// <returns>Private and public keys in PEM format</returns>
+      (string privateKey, string publicKey) NewEd25519KeyPair();
 
       /// <summary>
-      /// Decrypts and returns the provided Curve25519 private key
+      /// Get the user's secret, symmetric key.
       /// </summary>
       /// <param name="username"></param>
       /// <param name="password"></param>
-      /// <param name="userId"></param>
-      /// <returns>Private key in PEM format</returns>
-      public string DecryptPrivateKey(string username, string password, byte[] privateKey, byte[] iv);
+      /// <returns>Array of 32 bytes.</returns>
+      byte[] GetUserSymmetricKey(string username, string password);
    }
 
    public class UserKeysService : IUserKeysService
    {
-      public (byte[] encryptedPrivateKey, string publicKey, byte[] iv) GenerateNewX25519KeyPair(string username, string password)
+      private readonly ISimpleEncryptionService _simpleEncryptionService;
+
+      public UserKeysService(ISimpleEncryptionService simpleEncryptionService)
+      {
+         _simpleEncryptionService = simpleEncryptionService;
+      }
+
+      public (string privateKey, string publicKey) NewX25519KeyPair()
       {
          var keyPair = CryptoLib.Crypto.ECDH.GenerateKeys();
          var privateKey = CryptoLib.KeyConversion.ConvertToPEM(keyPair.Private);
          var publicKey = CryptoLib.KeyConversion.ConvertToPEM(keyPair.Public);
-         var iv = CryptoLib.Crypto.AES.GenerateIV();
-         var encryptedPrivateKey = EncryptPrivateKey(username, password, privateKey, iv);
 
-         return (encryptedPrivateKey, publicKey, iv);
+         return (privateKey, publicKey);
       }
 
-      public (byte[] encryptedPrivateKey, string publicKey, byte[] iv) GenerateNewEd25519KeyPair(string username, string password)
+      public (string privateKey, string publicKey) NewEd25519KeyPair()
       {
          var keyPair = CryptoLib.Crypto.ECDSA.GenerateKeys();
          var privateKey = CryptoLib.KeyConversion.ConvertToPEM(keyPair.Private);
          var publicKey = CryptoLib.KeyConversion.ConvertToPEM(keyPair.Public);
-         var iv = CryptoLib.Crypto.AES.GenerateIV();
-         var encryptedPrivateKey = EncryptPrivateKey(username, password, privateKey, iv);
 
-         return (encryptedPrivateKey, publicKey, iv);
+         return (privateKey, publicKey);
       }
 
-      public string DecryptPrivateKey(string username, string password, byte[] privateKey, byte[] iv)
+      public byte[] GetUserSymmetricKey(string username, string password)
       {
-         var key = CryptoLib.UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username, password);
-         var decrypter = new CryptoLib.Crypto.AES();
-         decrypter.Initialize(key, iv, false);
-         var decrypted = decrypter.ProcessFinal(privateKey);
-         return Encoding.UTF8.GetString(decrypted);
-      }
-
-      private static byte[] EncryptPrivateKey(string username, string password, string privatePemKey, byte[] iv)
-      {
-         var key = CryptoLib.UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username.ToLower(), password);
-         var encrypter = new CryptoLib.Crypto.AES();
-         encrypter.Initialize(key, iv, true);
-         return encrypter.ProcessFinal(Encoding.UTF8.GetBytes(privatePemKey));
+         return CryptoLib.UserFunctions.DeriveSymmetricKeyFromUserCredentials(username, password);
       }
    }
 }

--- a/Crypter.Web/Shared/LoginComponent.razor
+++ b/Crypter.Web/Shared/LoginComponent.razor
@@ -26,23 +26,30 @@
 
 @inherits LoginComponentBase
 
-<EditForm Model="@loginInfo" OnValidSubmit="@(e => OnLoginClicked())">
-   <DataAnnotationsValidator />
+<form>
+   <div class="mb-3">
+      <label for="usernameFormControl" class="form-label">Username</label>
+      <input @bind="LoginModel.Username" class="form-control @UsernameInvalidClass" id="usernameFormControl" />
+      <div class="invalid-feedback">@UsernameValidationMessage</div>
+   </div>
+
+   <div class="mb-3">
+      <label for="passwordFormControl" class="form-label">Password</label>
+      <input type="password" @bind="LoginModel.Password" class="form-control @PasswordInvalidClass" id="passwordFormControl" />
+      <div class="invalid-feedback">@PasswordValidationMessage</div>
+   </div>
+
    @if (LoginError)
    {
       <div class="alert alert-danger" role="alert">
          @LoginErrorText
       </div>
    }
-   <div class="mb-3">
-      <label for="usernameFormControl" class="form-label">Username</label>
-      <InputText @bind-Value="@loginInfo.Username" class="form-control" id="usernameFormControl" />
-      <ValidationMessage For="@(() => loginInfo.Username)" />
+
+   <div class="form-check form-switch">
+      <label class="form-check-label" for="rememberMe">Remember me on this device</label>
+      <input @bind="LoginModel.RememberMe" class="form-check-input" type="checkbox" id="rememberMe" />
    </div>
-   <div class="mb-3">
-      <label for="passwordFormControl" class="form-label">Password</label>
-      <InputText type="password" @bind-Value="@loginInfo.Password" class="form-control" id="passwordFormControl" />
-      <ValidationMessage For="@(() => loginInfo.Password)" />
-   </div>
-   <button type="submit" class="btn btn-primary">Login</button>
-</EditForm>
+
+   <button type="submit" class="btn btn-primary" @onclick:preventDefault @onclick="OnLoginClickedAsync">Login</button>
+</form>

--- a/Crypter.Web/Shared/LoginComponent.razor.cs
+++ b/Crypter.Web/Shared/LoginComponent.razor.cs
@@ -25,10 +25,9 @@
  */
 
 using Crypter.Web.Helpers;
-using Crypter.Web.Models;
+using Crypter.Web.Models.Forms;
 using Crypter.Web.Services;
 using Microsoft.AspNetCore.Components;
-using System;
 using System.Threading.Tasks;
 
 namespace Crypter.Web.Shared
@@ -44,10 +43,20 @@ namespace Crypter.Web.Shared
       [Inject]
       protected ILocalStorageService LocalStorage { get; set; }
 
-      protected Login loginInfo = new();
+      protected LoginModel LoginModel = new();
 
       protected bool LoginError = false;
       protected string LoginErrorText = "";
+
+      protected string IsInvalid = "is-invalid";
+
+      protected string UsernameInvalidClass = "";
+      protected string UsernameValidationMessage;
+      private readonly static string MissingUsername = "Please enter your username";
+
+      protected string PasswordInvalidClass = "";
+      protected string PasswordValidationMessage;
+      private readonly static string MissingPassword = "Please enter your password";
 
       protected override async Task OnInitializedAsync()
       {
@@ -58,12 +67,14 @@ namespace Crypter.Web.Shared
          await base.OnInitializedAsync();
       }
 
-      protected async Task OnLoginClicked()
+      protected async Task OnLoginClickedAsync()
       {
-         byte[] digestedPassword = CryptoLib.UserFunctions.DigestUserCredentials(loginInfo.Username, loginInfo.Password);
-         string digestedPasswordBase64 = Convert.ToBase64String(digestedPassword);
+         if (!ValidateForm())
+         {
+            return;
+         }
 
-         var authSuccess = await AuthenticationService.Login(loginInfo.Username, loginInfo.Password, digestedPasswordBase64);
+         var authSuccess = await AuthenticationService.LoginAsync(LoginModel.Username, LoginModel.Password, LoginModel.RememberMe);
          if (authSuccess)
          {
             var returnUrl = NavigationManager.QueryString("returnUrl") ?? "user/home";
@@ -73,6 +84,38 @@ namespace Crypter.Web.Shared
 
          LoginError = true;
          LoginErrorText = "Incorrect username or password";
+      }
+
+      private bool ValidateForm()
+      {
+         return ValidateUsername()
+            && ValidatePassword();
+      }
+
+      private bool ValidateUsername()
+      {
+         if (string.IsNullOrEmpty(LoginModel.Username))
+         {
+            UsernameValidationMessage = MissingUsername;
+            UsernameInvalidClass = IsInvalid;
+            return false;
+         }
+
+         UsernameInvalidClass = "";
+         return true;
+      }
+
+      private bool ValidatePassword()
+      {
+         if (string.IsNullOrEmpty(LoginModel.Password))
+         {
+            PasswordValidationMessage = MissingPassword;
+            PasswordInvalidClass = IsInvalid;
+            return false;
+         }
+
+         PasswordInvalidClass = "";
+         return true;
       }
    }
 }

--- a/Crypter.Web/Shared/MainLayout.razor
+++ b/Crypter.Web/Shared/MainLayout.razor
@@ -28,13 +28,22 @@
 @inherits MainLayoutBase
 
 <div class="page h-100">
-   <NavigationBar />
-   <main role="main" class="pb-3">
-      @if (LocalStorage.HasItem(StoredObjectType.UserSession))
-      {
-         <NavigationUser />
-      }
-      @Body
-   </main>
-   <Footer />
+   @if (LocalStorage.IsInitialized)
+   {
+      <NavigationBar />
+      <main role="main" class="pb-3">
+         
+         @if (LocalStorage.HasItem(StoredObjectType.UserSession))
+         {
+            <NavigationUser />
+            <ReAuthenticationModal @ref="ReAuthenticationModal" ModalClosedCallback="@OnReauthenticationModalClosed" />
+         }
+
+         @if (!UserNeedsReauthentication())
+         {
+            @Body
+         }
+      </main>
+      <Footer></Footer>
+   }
 </div>

--- a/Crypter.Web/Shared/Modal/ReAuthenticationModal.razor
+++ b/Crypter.Web/Shared/Modal/ReAuthenticationModal.razor
@@ -1,0 +1,58 @@
+﻿@*
+ * Copyright (C) 2021 Crypter File Transfer
+ * 
+ * This file is part of the Crypter file transfer project.
+ * 
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ * 
+ * Contact the current copyright holder to discuss commerical license options.
+ *@
+
+@inherits ReAuthenticationModalBase
+
+<div class="modal @ModalClass" tabindex="-1" role="dialog" style="display:@ModalDisplay">
+   <div class="modal-dialog" role="document">
+      <div class="modal-content">
+         <div class="modal-header">
+            <h3>Session Locked</h3>
+         </div>
+         <form>
+            <div class="modal-body justify-content-center">
+               <p class="word-wrap">Please provide your Crypter password to resume your session.</p>
+               <div class="mb-3">
+                  <input type="password" class="form-control" id="password" @bind="Password" placeholder="Password">
+                  @if (LoginFailed)
+                  {
+                     <span class="text-danger">Incorrect password</span>
+                  }
+               </div>
+            </div>
+            <div class="modal-footer">
+               <button type="button" class="btn btn-secondary" data-dismiss="modal" @onclick="OnLogoutClicked">Logout</button>
+               <button type="submit" class="btn btn-primary" data-dismiss="modal" @onclick:preventDefault @onclick="SubmitUnlockAsync">Unlock</button>
+            </div>
+         </form>
+      </div>
+   </div>
+</div>
+
+@if (ShowBackdrop)
+{
+   <div class="modal-backdrop fade show"></div>
+}

--- a/Crypter.Web/Shared/Modal/ReAuthenticationModal.razor.cs
+++ b/Crypter.Web/Shared/Modal/ReAuthenticationModal.razor.cs
@@ -1,0 +1,91 @@
+﻿/*
+ * Copyright (C) 2021 Crypter File Transfer
+ * 
+ * This file is part of the Crypter file transfer project.
+ * 
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ * 
+ * Contact the current copyright holder to discuss commerical license options.
+ */
+
+using Crypter.Web.Services;
+using Microsoft.AspNetCore.Components;
+using System.Threading.Tasks;
+
+namespace Crypter.Web.Shared.Modal
+{
+   public class ReAuthenticationModalBase : ComponentBase
+   {
+      [Inject]
+      private IAuthenticationService AuthenticationService { get; set; }
+
+      [Parameter]
+      public EventCallback<bool> ModalClosedCallback { get; set; }
+
+      protected string Password { get; set; } = null;
+      protected bool LoginFailed { get; set; } = false;
+
+      protected string ModalDisplay = "none;";
+      protected string ModalClass = "";
+      protected bool ShowBackdrop = false;
+
+      public void Open()
+      {
+         ModalDisplay = "block;";
+         ModalClass = "Show";
+         ShowBackdrop = true;
+         StateHasChanged();
+      }
+
+      public async Task<bool> PerformReauthentication()
+      {
+         if (string.IsNullOrEmpty(Password))
+         {
+            return false;
+         }
+
+         return await AuthenticationService.ReauthenticateAsync(Password);
+      }
+
+      public async Task SubmitUnlockAsync()
+      {
+         LoginFailed = false;
+
+         if (await PerformReauthentication())
+         {
+            ModalDisplay = "none";
+            ModalClass = "";
+            ShowBackdrop = false;
+            await ModalClosedCallback.InvokeAsync();
+            return;
+         }
+
+         LoginFailed = true;
+      }
+
+      public async Task OnLogoutClicked()
+      {
+         await AuthenticationService.LogoutAsync();
+         ModalDisplay = "none";
+         ModalClass = "";
+         ShowBackdrop = false;
+         await ModalClosedCallback.InvokeAsync();
+      }
+   }
+}

--- a/Crypter.Web/Shared/Modal/UploadFileTransferModal.razor.cs
+++ b/Crypter.Web/Shared/Modal/UploadFileTransferModal.razor.cs
@@ -76,8 +76,8 @@ namespace Crypter.Web.Shared.Modal
          if (LocalStorage.HasItem(StoredObjectType.UserSession))
          {
             IsSenderDefined = true;
-            SenderX25519PrivateKey = await LocalStorage.GetItem<string>(StoredObjectType.PlaintextX25519PrivateKey);
-            SenderEd25519PrivateKey = await LocalStorage.GetItem<string>(StoredObjectType.PlaintextEd25519PrivateKey);
+            SenderX25519PrivateKey = await LocalStorage.GetItemAsync<string>(StoredObjectType.PlaintextX25519PrivateKey);
+            SenderEd25519PrivateKey = await LocalStorage.GetItemAsync<string>(StoredObjectType.PlaintextEd25519PrivateKey);
          }
 
          ModalDisplay = "block;";

--- a/Crypter.Web/Shared/Modal/UploadMessageTransferModal.razor.cs
+++ b/Crypter.Web/Shared/Modal/UploadMessageTransferModal.razor.cs
@@ -76,8 +76,8 @@ namespace Crypter.Web.Shared.Modal
          if (LocalStorage.HasItem(StoredObjectType.UserSession))
          {
             IsSenderDefined = true;
-            SenderX25519PrivateKey = await LocalStorage.GetItem<string>(StoredObjectType.PlaintextX25519PrivateKey);
-            SenderEd25519PrivateKey = await LocalStorage.GetItem<string>(StoredObjectType.PlaintextEd25519PrivateKey);
+            SenderX25519PrivateKey = await LocalStorage.GetItemAsync<string>(StoredObjectType.PlaintextX25519PrivateKey);
+            SenderEd25519PrivateKey = await LocalStorage.GetItemAsync<string>(StoredObjectType.PlaintextEd25519PrivateKey);
          }
 
          ModalDisplay = "block;";

--- a/Crypter.Web/Shared/Navigation.razor
+++ b/Crypter.Web/Shared/Navigation.razor
@@ -32,16 +32,7 @@
 </button>
 <div class="collapse navbar-collapse justify-content-end" id="mainNavigation">
    <ul class="navbar-nav">
-      @if (!LocalStorageService.HasItem(StoredObjectType.UserSession))
-      {
-         <li class="nav-item m-1">
-            <a class="btn btn-secondary" href="/login">Login</a>
-         </li>
-         <li class="nav-item m-1">
-            <a class="btn btn-primary" href="/register">Sign Up</a>
-         </li>
-      }
-      else
+      @if (LocalStorageService.HasItem(StoredObjectType.UserSession))
       {
          <li class="nav-item mx-1">
             <a class="nav-link" href="#" @onclick:preventDefault @onclick="@OnLogoutClicked">Logout</a>
@@ -58,6 +49,15 @@
 
          <UploadFileTransferModal @ref="FileTransferModal" IsRecipientDefined=false ModalClosedCallback="@CollapseNavigationMenuAsync"/>
          <UploadMessageTransferModal @ref="MessageTransferModal" IsRecipientDefined=false ModalClosedCallback="@CollapseNavigationMenuAsync" />
+      }
+      else
+      {
+         <li class="nav-item m-1">
+            <a class="btn btn-secondary" href="/login">Login</a>
+         </li>
+         <li class="nav-item m-1">
+            <a class="btn btn-primary" href="/register">Sign Up</a>
+         </li>
       }
    </ul>
 </div>

--- a/Crypter.Web/Shared/Navigation.razor.cs
+++ b/Crypter.Web/Shared/Navigation.razor.cs
@@ -47,6 +47,7 @@ namespace Crypter.Web.Shared
       [Inject]
       protected IAuthenticationService AuthenticationService { get; set; }
 
+      protected bool UserIsAuthenticated { get; set; } = false;
       protected Modal.UploadFileTransferModal FileTransferModal { get; set; }
       protected Modal.UploadMessageTransferModal MessageTransferModal { get; set; }
 
@@ -58,7 +59,8 @@ namespace Crypter.Web.Shared
 
       protected void OnLogoutClicked()
       {
-         AuthenticationService.Logout();
+         AuthenticationService.LogoutAsync();
+         NavigationManager.NavigateTo("/");
       }
 
       protected void HandleLocationChanged(object sender, LocationChangedEventArgs e)

--- a/Crypter.Web/Shared/RegisterComponent.razor.cs
+++ b/Crypter.Web/Shared/RegisterComponent.razor.cs
@@ -46,13 +46,12 @@ namespace Crypter.Web.Shared
       [Inject]
       protected IUserApiService UserService { get; set; }
 
-      protected UserRegistration RegistrationInfo = new();
+      protected UserRegistrationModel RegistrationInfo = new();
 
       protected bool RegistrationError = false;
       protected string RegistrationErrorText = "";
       protected bool RegistrationSuccess = false;
 
-      protected string IsValid = "is-valid";
       protected string IsInvalid = "is-invalid";
 
       protected string UsernameInvalidClass = "";
@@ -81,29 +80,14 @@ namespace Crypter.Web.Shared
          await base.OnInitializedAsync();
       }
 
-      protected bool ValidateForm()
+      private bool ValidateForm()
       {
-         var formIsValid = true;
-
-         if (!ValidateUsername())
-         {
-            formIsValid = false;
-         }
-
-         if (!ValidatePassword())
-         {
-            formIsValid = false;
-         }
-
-         if (!ValidatePasswordConfirmation())
-         {
-            formIsValid = false;
-         }
-
-         return formIsValid;
+         return ValidateUsername()
+            && ValidatePassword()
+            && ValidatePasswordConfirmation();
       }
 
-      protected bool ValidateUsername()
+      private bool ValidateUsername()
       {
          if (string.IsNullOrEmpty(RegistrationInfo.Username))
          {
@@ -128,7 +112,7 @@ namespace Crypter.Web.Shared
          return true;
       }
 
-      protected bool ValidatePassword()
+      private bool ValidatePassword()
       {
          if (string.IsNullOrEmpty(RegistrationInfo.Password))
          {
@@ -141,7 +125,7 @@ namespace Crypter.Web.Shared
          return true;
       }
 
-      protected bool ValidatePasswordConfirmation()
+      private bool ValidatePasswordConfirmation()
       {
          if (string.IsNullOrEmpty(RegistrationInfo.PasswordConfirm))
          {
@@ -167,7 +151,7 @@ namespace Crypter.Web.Shared
             return;
          }
 
-         byte[] digestedPassword = CryptoLib.UserFunctions.DigestUserCredentials(RegistrationInfo.Username, RegistrationInfo.Password);
+         byte[] digestedPassword = CryptoLib.UserFunctions.DeriveAuthenticationPasswordFromUserCredentials(RegistrationInfo.Username, RegistrationInfo.Password);
          string digestedPasswordBase64 = Convert.ToBase64String(digestedPassword);
 
          var requestBody = new RegisterUserRequest(RegistrationInfo.Username, digestedPasswordBase64, RegistrationInfo.EmailAddress);

--- a/Crypter.Web/Shared/Transfer/DownloadTransferBase.cs
+++ b/Crypter.Web/Shared/Transfer/DownloadTransferBase.cs
@@ -28,6 +28,7 @@ using Crypter.CryptoLib;
 using Crypter.CryptoLib.Crypto;
 using Crypter.CryptoLib.Enums;
 using Crypter.Web.Models;
+using Crypter.Web.Models.LocalStorage;
 using Crypter.Web.Services;
 using Crypter.Web.Services.API;
 using Microsoft.AspNetCore.Components;
@@ -115,7 +116,7 @@ namespace Crypter.Web.Shared.Transfer
             IsUserRecipient = false;
             return;
          }
-         var session = await LocalStorageService.GetItem<UserSession>(StoredObjectType.UserSession);
+         var session = await LocalStorageService.GetItemAsync<UserSession>(StoredObjectType.UserSession);
          IsUserRecipient = RecipientId.Equals(session.UserId);
       }
 
@@ -125,7 +126,7 @@ namespace Crypter.Web.Shared.Transfer
       {
          if (IsUserRecipient)
          {
-            return (true, await LocalStorageService.GetItem<string>(StoredObjectType.PlaintextX25519PrivateKey));
+            return (true, await LocalStorageService.GetItemAsync<string>(StoredObjectType.PlaintextX25519PrivateKey));
          }
 
          try

--- a/Crypter.sln
+++ b/Crypter.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31129.286
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Crypter.API", "Crypter.API\Crypter.API.csproj", "{F9208A53-1847-4B7E-A867-C5D17F52410C}"
 EndProject
@@ -16,7 +16,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Crypter.Test", "Crypter.Tes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Crypter.Console", "Crypter.Console\Crypter.Console.csproj", "{7D8A5A7F-4C0D-4F48-8913-ACCCD945DE82}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Crypter.Common", "Crypter.Common\Crypter.Common.csproj", "{BB1D0B65-34E4-4B9B-9752-CA2F6BEE9F6A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Crypter.Common", "Crypter.Common\Crypter.Common.csproj", "{BB1D0B65-34E4-4B9B-9752-CA2F6BEE9F6A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Resolve #166 

When I removed the "beta key" requirement from Crypter, I also chose to begin storing the user's secrets (JWT, private keys) in memory rather than use session storage or local storage.  This was for security reasons - I did not want to put any new users at risk by storing their sensitive information, in plaintext, in a location where malicious javascript has access to.

This pull request adds the concept of "re-authentication" and stores **non-sensitive** information in session storage and local storage again.

Items stored in session storage or local storage are:

- User ID
- Username
- Encrypted JWT
- Encrypted private keys

Items stored in memory are:

- Plaintext JWT
- Plaintext private keys

The "Remember me on this device" switch, now located on the login page, controls whether information will be stored in session storage **or** local storage.  This pull request does not implement refresh tokens.  That will be accomplished later.

Expected behavior:

Once a user is logged in, refreshing the page will prompt the user to re-authenticate.

If a user has chosen "Remember me on this device" when signing in, the user will also be prompted to re-authenticate when they open Crypter in a new tab.  If the user did not choose this option, the user will not be signed in on the new tab.  This is the difference between using session storage and local storage.