### PR TITLE
Client should provide unique initialization vectors for private key encryption

### DIFF
--- a/Crypter.API/Controllers/UserController.cs
+++ b/Crypter.API/Controllers/UserController.cs
@@ -56,8 +56,8 @@ namespace Crypter.API.Controllers
    {
       private readonly IUserService UserService;
       private readonly IUserProfileService UserProfileService;
-      private readonly IUserPublicKeyPairService<UserX25519KeyPair> UserDiffieHellmanKeyPairService;
-      private readonly IUserPublicKeyPairService<UserEd25519KeyPair> UserDigitalSignatureKeyPairService;
+      private readonly IUserPublicKeyPairService<UserX25519KeyPair> UserX25519KeyPairService;
+      private readonly IUserPublicKeyPairService<UserEd25519KeyPair> UserEd25519KeyPairService;
       private readonly IUserSearchService UserSearchService;
       private readonly IUserPrivacySettingService UserPrivacySettingService;
       private readonly IUserEmailVerificationService UserEmailVerificationService;
@@ -71,8 +71,8 @@ namespace Crypter.API.Controllers
       public UserController(
           IUserService userService,
           IUserProfileService userProfileService,
-          IUserPublicKeyPairService<UserX25519KeyPair> userDiffieHellmanKeyPairService,
-          IUserPublicKeyPairService<UserEd25519KeyPair> userDigitalSignatureKeyPairService,
+          IUserPublicKeyPairService<UserX25519KeyPair> userX25519KeyPairService,
+          IUserPublicKeyPairService<UserEd25519KeyPair> userEd25519KeyPairService,
           IUserSearchService userSearchService,
           IUserPrivacySettingService userPrivacySettingService,
           IUserEmailVerificationService userEmailVerificationService,
@@ -86,8 +86,8 @@ namespace Crypter.API.Controllers
       {
          UserService = userService;
          UserProfileService = userProfileService;
-         UserDiffieHellmanKeyPairService = userDiffieHellmanKeyPairService;
-         UserDigitalSignatureKeyPairService = userDigitalSignatureKeyPairService;
+         UserX25519KeyPairService = userX25519KeyPairService;
+         UserEd25519KeyPairService = userEd25519KeyPairService;
          UserSearchService = userSearchService;
          UserPrivacySettingService = userPrivacySettingService;
          UserEmailVerificationService = userEmailVerificationService;
@@ -147,13 +147,13 @@ namespace Crypter.API.Controllers
          var token = tokenHandler.CreateToken(tokenDescriptor);
          var tokenString = tokenHandler.WriteToken(token);
 
-         var userDHKeyPair = await UserDiffieHellmanKeyPairService.GetUserPublicKeyPairAsync(user.Id);
-         var userDSAKeyPair = await UserDigitalSignatureKeyPairService.GetUserPublicKeyPairAsync(user.Id);
+         var userX25519KeyPair = await UserX25519KeyPairService.GetUserPublicKeyPairAsync(user.Id);
+         var userEd25519KeyPair = await UserEd25519KeyPairService.GetUserPublicKeyPairAsync(user.Id);
 
          BackgroundJob.Enqueue(() => UserService.UpdateLastLoginTime(user.Id, DateTime.UtcNow));
 
          return new OkObjectResult(
-             new UserAuthenticateResponse(user.Id, tokenString, userDHKeyPair?.PrivateKey, userDSAKeyPair?.PrivateKey)
+             new UserAuthenticateResponse(user.Id, tokenString, userX25519KeyPair?.PrivateKey, userEd25519KeyPair?.PrivateKey, userX25519KeyPair.ClientIV, userEd25519KeyPair.ClientIV)
          );
       }
 
@@ -420,7 +420,7 @@ namespace Crypter.API.Controllers
       {
          var userId = ClaimsParser.ParseUserId(User);
 
-         var insertResult = await UserDiffieHellmanKeyPairService.InsertUserPublicKeyPairAsync(userId, body.EncryptedPrivateKeyBase64, body.PublicKey);
+         var insertResult = await UserX25519KeyPairService.InsertUserPublicKeyPairAsync(userId, body.EncryptedPrivateKeyBase64, body.PublicKeyBase64, body.ClientIVBase64);
          if (insertResult)
          {
             return new OkObjectResult(
@@ -439,7 +439,7 @@ namespace Crypter.API.Controllers
       {
          var userId = ClaimsParser.ParseUserId(User);
 
-         var insertResult = await UserDigitalSignatureKeyPairService.InsertUserPublicKeyPairAsync(userId, body.EncryptedPrivateKeyBase64, body.PublicKey);
+         var insertResult = await UserEd25519KeyPairService.InsertUserPublicKeyPairAsync(userId, body.EncryptedPrivateKeyBase64, body.PublicKeyBase64, body.ClientIVBase64);
          if (insertResult)
          {
             return new OkObjectResult(
@@ -508,8 +508,8 @@ namespace Crypter.API.Controllers
          var userAllowsRequestorToViewProfile = await UserPrivacySettingService.IsUserViewableByPartyAsync(user.Id, requestor);
          if (userAllowsRequestorToViewProfile)
          {
-            var userPublicDHKey = await UserDiffieHellmanKeyPairService.GetUserPublicKeyAsync(user.Id);
-            var userPublicDSAKey = await UserDigitalSignatureKeyPairService.GetUserPublicKeyAsync(user.Id);
+            var userPublicDHKey = await UserX25519KeyPairService.GetUserPublicKeyAsync(user.Id);
+            var userPublicDSAKey = await UserEd25519KeyPairService.GetUserPublicKeyAsync(user.Id);
 
             var visitorCanSendMessages = await UserPrivacySettingService.DoesUserAcceptMessagesFromOtherPartyAsync(user.Id, visitorId);
             var visitorCanSendFiles = await UserPrivacySettingService.DoesUserAcceptFilesFromOtherPartyAsync(user.Id, visitorId);

--- a/Crypter.Console/Crypter.Console.csproj
+++ b/Crypter.Console/Crypter.Console.csproj
@@ -86,6 +86,9 @@
     <None Update="SqlScripts\Crypter\Drop\Drop_UserX25519KeyPair.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="SqlScripts\Crypter\Migrations\Migration2.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="SqlScripts\Crypter\Migrations\Migration1.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Crypter.Console/Jobs/Help.cs
+++ b/Crypter.Console/Jobs/Help.cs
@@ -33,11 +33,11 @@ namespace Crypter.Console.Jobs
          System.Console.WriteLine(@"
 Commands:
 
-    -h --help /?            Show this menu
-    -d --delete-expired     Delete expired uploads
-    --create-schema {connection-string}       Create tables for the 'crypter' database
-    --migrate-schema-v1 {connection-string}   Migrate the 'crypter' database to schema v1
-    --delete-schema {connection-string}       Delete tables for the 'crypter' database
+    -h --help /?                                      Show this menu
+    -d --delete-expired                               Delete expired uploads
+    --create-schema {connection-string}               Create tables for the 'crypter' database
+    --migrate-schema {filename} {connection-string}   Migrate the 'crypter' database schema
+    --delete-schema {connection-string}               Delete tables for the 'crypter' database
 ");
       }
    }

--- a/Crypter.Console/Jobs/ManageSchema.cs
+++ b/Crypter.Console/Jobs/ManageSchema.cs
@@ -109,17 +109,17 @@ namespace Crypter.Console.Jobs
       }
       
       /// <summary>
-      /// Perform the first, codified migration of the Crypter database.
+      /// Perform a migration of the Crypter database.
       /// </summary>
       /// <returns></returns>
-      public async Task PerformInitialMigration()
+      public async Task PerformMigration(string filename)
       {
          await using var connection = new NpgsqlConnection(ConnectionString);
          await connection.OpenAsync();
 
          try
          {
-            var migration = await GetMigrationScriptAsync("Migration1.sql");
+            var migration = await GetMigrationScriptAsync(filename);
             ExecuteSqlScriptNonQuery(connection, migration);
          }
          catch (System.Exception e)

--- a/Crypter.Console/Program.cs
+++ b/Crypter.Console/Program.cs
@@ -82,17 +82,24 @@ namespace Crypter.Console
             return 0;
          }
 
-         if (RequestInitialCrypterMigration(args[0]))
+         if (RequestCrypterSchemaMigration(args[0]))
          {
             if (args.Length < 2)
             {
-               System.Console.WriteLine("This command requires a connection string as the second argument");
+               System.Console.WriteLine("This command requires a filename as the second argument");
                return -2;
             }
 
-            var connectionString = args[1];
+            if (args.Length < 3)
+            {
+               System.Console.WriteLine("This command requires a connection string as the third argument");
+               return -2;
+            }
+
+            var migrationFilename = args[1];
+            var connectionString = args[2];
             var schemaManager = new ManageSchema(connectionString);
-            await schemaManager.PerformInitialMigration();
+            await schemaManager.PerformMigration(migrationFilename);
             return 0;
          }
 
@@ -137,9 +144,9 @@ namespace Crypter.Console
          return param == "--create-schema";
       }
 
-      private static bool RequestInitialCrypterMigration(string param)
+      private static bool RequestCrypterSchemaMigration(string param)
       {
-         return param == "--migrate-schema-v1";
+         return param == "--migrate-schema";
       }
 
       private static bool RequestDeleteCrypterSchema(string param)

--- a/Crypter.Console/SqlScripts/Crypter/Create/Create_UserEd25519KeyPair.sql
+++ b/Crypter.Console/SqlScripts/Crypter/Create/Create_UserEd25519KeyPair.sql
@@ -32,6 +32,7 @@ CREATE TABLE IF NOT EXISTS public."UserEd25519KeyPair"
     "Owner" uuid NOT NULL,
     "PrivateKey" text COLLATE pg_catalog."default",
     "PublicKey" text COLLATE pg_catalog."default",
+    "ClientIV" text COLLATE pg_catalog."default",
     "Created" timestamp without time zone NOT NULL,
     CONSTRAINT "PK_UserEd25519KeyPair" PRIMARY KEY ("Id"),
     CONSTRAINT "FK_UserEd25519KeyPair_User_Owner" FOREIGN KEY ("Owner")

--- a/Crypter.Console/SqlScripts/Crypter/Create/Create_UserX25519KeyPair.sql
+++ b/Crypter.Console/SqlScripts/Crypter/Create/Create_UserX25519KeyPair.sql
@@ -32,6 +32,7 @@ CREATE TABLE IF NOT EXISTS public."UserX25519KeyPair"
     "Owner" uuid NOT NULL,
     "PrivateKey" text COLLATE pg_catalog."default",
     "PublicKey" text COLLATE pg_catalog."default",
+    "ClientIV" text COLLATE pg_catalog."default",
     "Created" timestamp without time zone NOT NULL,
     CONSTRAINT "PK_UserX25519KeyPair" PRIMARY KEY("Id"),
     CONSTRAINT "FK_UserX25519KeyPair_User_Owner" FOREIGN KEY("Owner")

--- a/Crypter.Console/SqlScripts/Crypter/Migrations/Migration2.sql
+++ b/Crypter.Console/SqlScripts/Crypter/Migrations/Migration2.sql
@@ -24,24 +24,28 @@
  * Contact the current copyright holder to discuss commerical license options.
  */
 
--- Table: public.Schema
+BEGIN;
 
-CREATE TABLE IF NOT EXISTS public."Schema"
-(
-    "Version" integer NOT NULL,
-    "Updated" timestamp without time zone NOT NULL
-)
+   -- Alter UserX25519KeyPair
 
-TABLESPACE pg_default;
+   ALTER TABLE IF EXISTS public."UserX25519KeyPair"
+      ADD COLUMN "ClientIV" text COLLATE pg_catalog."default";
 
-ALTER TABLE IF EXISTS public."Schema"
-    OWNER to postgres;
+   -- Alter UserEd25519KeyPair
 
-GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE public."Schema" TO cryptuser;
+   ALTER TABLE IF EXISTS public."UserEd25519KeyPair"
+      ADD COLUMN "ClientIV" text COLLATE pg_catalog."default";
 
-GRANT ALL ON TABLE public."Schema" TO postgres;
+   -- Delete rows from UserX25519KeyPair
 
--- Insert current schema version
+   DELETE FROM public."UserX25519KeyPair";
 
-INSERT INTO public."Schema" ("Version", "Updated")
-   VALUES (2, CURRENT_TIMESTAMP);
+   -- Delete rows from UserX25519KeyPair
+
+   DELETE FROM public."UserEd25519KeyPair";
+
+   -- Update schema version
+
+   UPDATE public."Schema" SET "Version" = 2, "Updated" = CURRENT_TIMESTAMP;
+
+COMMIT;

--- a/Crypter.Contracts/Requests/User/UpdateKeysRequest.cs
+++ b/Crypter.Contracts/Requests/User/UpdateKeysRequest.cs
@@ -31,13 +31,15 @@ namespace Crypter.Contracts.Requests
    public class UpdateKeysRequest
    {
       public string EncryptedPrivateKeyBase64 { get; set; }
-      public string PublicKey { get; set; }
+      public string PublicKeyBase64 { get; set; }
+      public string ClientIVBase64 { get; set; }
 
       [JsonConstructor]
-      public UpdateKeysRequest(string encryptedPrivateKeyBase64, string publicKey)
+      public UpdateKeysRequest(string encryptedPrivateKeyBase64, string publicKeyBase64, string clientIVBase64)
       {
          EncryptedPrivateKeyBase64 = encryptedPrivateKeyBase64;
-         PublicKey = publicKey;
+         PublicKeyBase64 = publicKeyBase64;
+         ClientIVBase64 = clientIVBase64;
       }
    }
 }

--- a/Crypter.Contracts/Responses/User/UserAuthenticateResponse.cs
+++ b/Crypter.Contracts/Responses/User/UserAuthenticateResponse.cs
@@ -35,14 +35,18 @@ namespace Crypter.Contracts.Responses
       public string Token { get; set; }
       public string EncryptedX25519PrivateKey { get; set; }
       public string EncryptedEd25519PrivateKey { get; set; }
+      public string X25519IV { get; set; }
+      public string Ed25519IV { get; set; }
 
       [JsonConstructor]
-      public UserAuthenticateResponse(Guid id, string token, string encryptedX25519PrivateKey = null, string encryptedEd25519PrivateKey = null)
+      public UserAuthenticateResponse(Guid id, string token, string encryptedX25519PrivateKey = null, string encryptedEd25519PrivateKey = null, string x25519IV = null, string ed25519IV = null)
       {
          Id = id;
          Token = token;
          EncryptedX25519PrivateKey = encryptedX25519PrivateKey;
          EncryptedEd25519PrivateKey = encryptedEd25519PrivateKey;
+         X25519IV = x25519IV;
+         Ed25519IV = ed25519IV;
       }
    }
 }

--- a/Crypter.Core/Interfaces/DataModel/IUserPublicKeyPair.cs
+++ b/Crypter.Core/Interfaces/DataModel/IUserPublicKeyPair.cs
@@ -34,6 +34,7 @@ namespace Crypter.Core.Interfaces
       public Guid Owner { get; set; }
       public string PrivateKey { get; set; }
       public string PublicKey { get; set; }
+      public string ClientIV { get; set; }
       public DateTime Created { get; set; }
    }
 }

--- a/Crypter.Core/Interfaces/DataService/IUserPublicKeyPairService.cs
+++ b/Crypter.Core/Interfaces/DataService/IUserPublicKeyPairService.cs
@@ -33,6 +33,6 @@ namespace Crypter.Core.Interfaces
    {
       Task<IUserPublicKeyPair> GetUserPublicKeyPairAsync(Guid userId);
       Task<string> GetUserPublicKeyAsync(Guid userId);
-      Task<bool> InsertUserPublicKeyPairAsync(Guid userId, string privateKey, string publicKey);
+      Task<bool> InsertUserPublicKeyPairAsync(Guid userId, string privateKey, string publicKey, string clientIV);
    }
 }

--- a/Crypter.Core/Models/UserEd25519KeyPair.cs
+++ b/Crypter.Core/Models/UserEd25519KeyPair.cs
@@ -40,16 +40,18 @@ namespace Crypter.Core.Models
       public Guid Owner { get; set; }
       public string PrivateKey { get; set; }
       public string PublicKey { get; set; }
+      public string ClientIV { get; set; }
       public DateTime Created { get; set; }
 
       public virtual User User { get; set; }
 
-      public UserEd25519KeyPair(Guid id, Guid owner, string privateKey, string publicKey, DateTime created)
+      public UserEd25519KeyPair(Guid id, Guid owner, string privateKey, string publicKey, string clientIV, DateTime created)
       {
          Id = id;
          Owner = owner;
          PrivateKey = privateKey;
          PublicKey = publicKey;
+         ClientIV = clientIV;
          Created = created;
       }
    }

--- a/Crypter.Core/Models/UserX25519KeyPair.cs
+++ b/Crypter.Core/Models/UserX25519KeyPair.cs
@@ -40,16 +40,18 @@ namespace Crypter.Core.Models
       public Guid Owner { get; set; }
       public string PrivateKey { get; set; }
       public string PublicKey { get; set; }
+      public string ClientIV { get; set; }
       public DateTime Created { get; set; }
 
       public virtual User User { get; set; }
 
-      public UserX25519KeyPair(Guid id, Guid owner, string privateKey, string publicKey, DateTime created)
+      public UserX25519KeyPair(Guid id, Guid owner, string privateKey, string publicKey, string clientIV, DateTime created)
       {
          Id = id;
          Owner = owner;
          PrivateKey = privateKey;
          PublicKey = publicKey;
+         ClientIV = clientIV;
          Created = created;
       }
    }

--- a/Crypter.Core/Services/DataAccess/UserEd25519KeyPairService.cs
+++ b/Crypter.Core/Services/DataAccess/UserEd25519KeyPairService.cs
@@ -57,7 +57,7 @@ namespace Crypter.Core.Services.DataAccess
          return keyPair?.PublicKey;
       }
 
-      public async Task<bool> InsertUserPublicKeyPairAsync(Guid userId, string privateKey, string publicKey)
+      public async Task<bool> InsertUserPublicKeyPairAsync(Guid userId, string privateKey, string publicKey, string clientIV)
       {
          if (await GetUserPublicKeyPairAsync(userId) != default(UserEd25519KeyPair))
          {
@@ -69,6 +69,7 @@ namespace Crypter.Core.Services.DataAccess
              userId,
              privateKey,
              publicKey,
+             clientIV,
              DateTime.UtcNow);
 
          Context.UserEd25519KeyPair.Add(key);

--- a/Crypter.Core/Services/DataAccess/UserX25519KeyPairService.cs
+++ b/Crypter.Core/Services/DataAccess/UserX25519KeyPairService.cs
@@ -57,7 +57,7 @@ namespace Crypter.Core.Services.DataAccess
          return keyPair?.PublicKey;
       }
 
-      public async Task<bool> InsertUserPublicKeyPairAsync(Guid userId, string privateKey, string publicKey)
+      public async Task<bool> InsertUserPublicKeyPairAsync(Guid userId, string privateKey, string publicKey, string clientIV)
       {
          if (await GetUserPublicKeyPairAsync(userId) != default(UserX25519KeyPair))
          {
@@ -69,6 +69,7 @@ namespace Crypter.Core.Services.DataAccess
              userId,
              privateKey,
              publicKey,
+             clientIV,
              DateTime.UtcNow);
 
          Context.UserX25519KeyPair.Add(key);

--- a/Crypter.CryptoLib/UserFunctions.cs
+++ b/Crypter.CryptoLib/UserFunctions.cs
@@ -25,13 +25,21 @@
  */
 
 using Crypter.CryptoLib.Enums;
-using System;
 using System.Text;
 
 namespace Crypter.CryptoLib
 {
    public static class UserFunctions
    {
+      /// <summary>
+      /// Digest a user's login information.
+      /// </summary>
+      /// <param name="username"></param>
+      /// <param name="password"></param>
+      /// <returns>Array of 64 bytes.</returns>
+      /// <remarks>
+      /// The result of this method is used as the user's password during authentication requests.
+      /// </remarks>
       public static byte[] DigestUserCredentials(string username, string password)
       {
          var digestor = new Crypto.SHA(SHAFunction.SHA512);
@@ -41,23 +49,17 @@ namespace Crypter.CryptoLib
       }
 
       /// <summary>
-      /// Create the symmetric parameters to encrypt/decrypt a user's stored data
+      /// Derive a symmetric encryption key from the user's login information
       /// </summary>
       /// <param name="username"></param>
       /// <param name="password"></param>
-      /// <param name="userId"></param>
-      /// <returns></returns>
-      public static (byte[] Key, byte[] IV) DeriveSymmetricCryptoParamsFromUserDetails(string username, string password, Guid userId)
+      /// <returns>Array of 32 bytes.</returns>
+      public static byte[] DeriveSymmetricCryptoParamsFromUserDetails(string username, string password)
       {
          var keyDigestor = new Crypto.SHA(SHAFunction.SHA256);
          keyDigestor.BlockUpdate(Encoding.UTF8.GetBytes(username.ToLower()));
          keyDigestor.BlockUpdate(Encoding.UTF8.GetBytes(password));
-         var key = keyDigestor.GetDigest();
-
-         var ivDigestor = new Crypto.SHA(SHAFunction.SHA256);
-         ivDigestor.BlockUpdate(Encoding.UTF8.GetBytes(userId.ToString().ToLower()));
-         var iv = ivDigestor.GetDigest()[0..16];
-         return (key, iv);
+         return keyDigestor.GetDigest();
       }
    }
 }

--- a/Crypter.Test/CryptoLib_Tests/UserFunctions_Tests.cs
+++ b/Crypter.Test/CryptoLib_Tests/UserFunctions_Tests.cs
@@ -26,7 +26,6 @@
 
 using Crypter.CryptoLib;
 using NUnit.Framework;
-using System;
 
 namespace Crypter.Test.CryptoLib_Tests
 {
@@ -85,11 +84,10 @@ namespace Crypter.Test.CryptoLib_Tests
       }
 
       [Test]
-      public void Symmetric_Crypto_Params_Can_Be_Derived_From_User_Details()
+      public void Symmetric_Key_Can_Be_Derived_From_User_Login_Information()
       {
          var username = "Samwise";
          var password = "Gamgee";
-         var userId = Guid.Parse("77164afe-2c54-4b4a-b2aa-1a35bf2101b9");
 
          var knownKey = new byte[]
          {
@@ -99,43 +97,32 @@ namespace Crypter.Test.CryptoLib_Tests
             0xfb, 0x91, 0x38, 0x41, 0x2d, 0xa4, 0xde, 0x52
          };
 
-         var knownIV = new byte[]
-         {
-            0x18, 0xd0, 0xaf, 0x02, 0x1f, 0x4f, 0xa9, 0x13,
-            0xb1, 0xe5, 0x22, 0x1b, 0x37, 0x52, 0xf5, 0x22
-         };
-
-         (var key, var iv) = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username, password, userId);
+         var key = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username, password);
          Assert.AreEqual(knownKey, key);
-         Assert.AreEqual(knownIV, iv);
       }
 
       [Test]
-      public void Symmetric_Crypto_Params_Can_Be_Derived_From_User_Details_Username_Is_Case_Insensitive()
+      public void Symmetric_Key_Derivation_Outputs_Same_Key_Regardless_Of_Username_Capitalization()
       {
          var usernameLowercase = "gimli";
          var usernameUppercase = "GIMLI";
          var password = "TheDwarf";
-         var userId = Guid.NewGuid();
 
-         (var lowercaseKey, var lowercaseIV) = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(usernameLowercase, password, userId);
-         (var uppercaseKey, var uppercaseIV) = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(usernameUppercase, password, userId);
+         var lowercaseKey = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(usernameLowercase, password);
+         var uppercaseKey = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(usernameUppercase, password);
          Assert.AreEqual(lowercaseKey, uppercaseKey);
-         Assert.AreEqual(lowercaseIV, uppercaseIV);
       }
 
       [Test]
-      public void Symmetric_Crypto_Params_Can_Be_Derived_From_User_Details_Password_Is_Case_Sensitive()
+      public void Symmetric_Key_Derivation_Different_Key_When_Password_Capitalization_Changes()
       {
          var username = "Aragon";
          var lowercasePassword = "son_of_arathorn";
          var uppercasePassword = "SON_OF_ARATHORN";
-         var userId = Guid.NewGuid();
 
-         (var lowercaseKey, var lowercaseIV) = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username, lowercasePassword, userId);
-         (var uppercaseKey, var uppercaseIV) = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username, uppercasePassword, userId);
+         var lowercaseKey = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username, lowercasePassword);
+         var uppercaseKey = UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username, uppercasePassword);
          Assert.AreNotEqual(lowercaseKey, uppercaseKey);
-         Assert.AreEqual(lowercaseIV, uppercaseIV); // IV is derived from the userId
       }
    }
 }

--- a/Crypter.Web/Pages/UserProfile.razor
+++ b/Crypter.Web/Pages/UserProfile.razor
@@ -33,7 +33,7 @@
       <div class="col-md-6 offset-md-3">
          @if (!Loading)
          {
-            if (ProfileFound)
+            if (IsProfileAvailable)
             {
                @if (!string.IsNullOrEmpty(Alias))
                {

--- a/Crypter.Web/Pages/UserProfile.razor.cs
+++ b/Crypter.Web/Pages/UserProfile.razor.cs
@@ -53,7 +53,7 @@ namespace Crypter.Web.Pages
       protected Shared.Modal.UploadMessageTransferModal MessageModal { get; set; }
 
       protected bool Loading;
-      protected bool ProfileFound;
+      protected bool IsProfileAvailable;
       protected Guid UserId;
       protected string Alias;
       protected string About;
@@ -79,8 +79,11 @@ namespace Crypter.Web.Pages
       {
          var requestWithAuthentication = LocalStorage.HasItem(StoredObjectType.UserSession);
          var (httpStatus, response) = await UserService.GetUserPublicProfileAsync(Username, requestWithAuthentication);
-         ProfileFound = httpStatus != HttpStatusCode.NotFound;
-         if (ProfileFound)
+         IsProfileAvailable = httpStatus == HttpStatusCode.OK
+            && !string.IsNullOrEmpty(response.PublicDHKey)
+            && !string.IsNullOrEmpty(response.PublicDSAKey);
+
+         if (IsProfileAvailable)
          {
             UserId = response.Id;
             Alias = response.Alias;

--- a/Crypter.Web/Services/UserKeysService.cs
+++ b/Crypter.Web/Services/UserKeysService.cs
@@ -38,7 +38,7 @@ namespace Crypter.Web.Services
       /// <param name="username"></param>
       /// <param name="password"></param>
       /// <returns>Encrypted private key and plaintext public key in PEM format</returns>
-      (byte[] encryptedPrivateKey, string publicKey) GenerateNewX25519KeyPair(Guid userId, string username, string password);
+      (byte[] encryptedPrivateKey, string publicKey, byte [] iv) GenerateNewX25519KeyPair(string username, string password);
 
       /// <summary>
       /// Generate a new Ed25519 key pair.
@@ -47,7 +47,7 @@ namespace Crypter.Web.Services
       /// <param name="username"></param>
       /// <param name="password"></param>
       /// <returns>Encrypted private key and plaintext public key in PEM format</returns>
-      public (byte[] encryptedPrivateKey, string publicKey) GenerateNewEd25519KeyPair(Guid userId, string username, string password);
+      public (byte[] encryptedPrivateKey, string publicKey, byte[] iv) GenerateNewEd25519KeyPair(string username, string password);
 
       /// <summary>
       /// Decrypts and returns the provided Curve25519 private key
@@ -56,43 +56,45 @@ namespace Crypter.Web.Services
       /// <param name="password"></param>
       /// <param name="userId"></param>
       /// <returns>Private key in PEM format</returns>
-      public string DecryptPrivateKey(string username, string password, Guid userId, byte[] privateKey);
+      public string DecryptPrivateKey(string username, string password, byte[] privateKey, byte[] iv);
    }
 
    public class UserKeysService : IUserKeysService
    {
-      public (byte[] encryptedPrivateKey, string publicKey) GenerateNewX25519KeyPair(Guid userId, string username, string password)
+      public (byte[] encryptedPrivateKey, string publicKey, byte[] iv) GenerateNewX25519KeyPair(string username, string password)
       {
          var keyPair = CryptoLib.Crypto.ECDH.GenerateKeys();
          var privateKey = CryptoLib.KeyConversion.ConvertToPEM(keyPair.Private);
          var publicKey = CryptoLib.KeyConversion.ConvertToPEM(keyPair.Public);
-         var encryptedPrivateKey = EncryptPrivateKey(privateKey, userId, username, password);
+         var iv = CryptoLib.Crypto.AES.GenerateIV();
+         var encryptedPrivateKey = EncryptPrivateKey(username, password, privateKey, iv);
 
-         return (encryptedPrivateKey, publicKey);
+         return (encryptedPrivateKey, publicKey, iv);
       }
 
-      public (byte[] encryptedPrivateKey, string publicKey) GenerateNewEd25519KeyPair(Guid userId, string username, string password)
+      public (byte[] encryptedPrivateKey, string publicKey, byte[] iv) GenerateNewEd25519KeyPair(string username, string password)
       {
          var keyPair = CryptoLib.Crypto.ECDSA.GenerateKeys();
          var privateKey = CryptoLib.KeyConversion.ConvertToPEM(keyPair.Private);
          var publicKey = CryptoLib.KeyConversion.ConvertToPEM(keyPair.Public);
-         var encryptedPrivateKey = EncryptPrivateKey(privateKey, userId, username, password);
+         var iv = CryptoLib.Crypto.AES.GenerateIV();
+         var encryptedPrivateKey = EncryptPrivateKey(username, password, privateKey, iv);
 
-         return (encryptedPrivateKey, publicKey);
+         return (encryptedPrivateKey, publicKey, iv);
       }
 
-      public string DecryptPrivateKey(string username, string password, Guid userId, byte[] privateKey)
+      public string DecryptPrivateKey(string username, string password, byte[] privateKey, byte[] iv)
       {
-         (var key, var iv) = CryptoLib.UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username, password, userId);
+         var key = CryptoLib.UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username, password);
          var decrypter = new CryptoLib.Crypto.AES();
          decrypter.Initialize(key, iv, false);
          var decrypted = decrypter.ProcessFinal(privateKey);
          return Encoding.UTF8.GetString(decrypted);
       }
 
-      private static byte[] EncryptPrivateKey(string privatePemKey, Guid userId, string username, string password)
+      private static byte[] EncryptPrivateKey(string username, string password, string privatePemKey, byte[] iv)
       {
-         (var key, var iv) = CryptoLib.UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username.ToLower(), password, userId);
+         var key = CryptoLib.UserFunctions.DeriveSymmetricCryptoParamsFromUserDetails(username.ToLower(), password);
          var encrypter = new CryptoLib.Crypto.AES();
          encrypter.Initialize(key, iv, true);
          return encrypter.ProcessFinal(Encoding.UTF8.GetBytes(privatePemKey));


### PR DESCRIPTION
Resolve #168 

The purpose of this change is to stop using the same initialization vector to encrypt both a user's private X25519 and private Ed25519 keys.  Re-using the same initialization vector, for a given symmetric key, is bad practice.

This change requires an update to the database schema.  This pull request will add schema version 2.  The way this schema migration is handled is a little destructive; every user key-pair will be deleted during the migration.  I am taking the stance that whatever keys are currently saved in the database today are less secure than if we generated and encrypted new ones.

This will negatively impact registered users to an extent.  Although Crypter.Web is coded to create and upload new key-pairs if they do not exist, Crypter.Web will experience an unhandled exception when trying to decrypt any transfers that were encrypted using the old keys.  This "outage" will resolve itself within a day, as these transfers expire and are deleted.

I will need to notify existing users to login after this change takes place, that way they can create their new keys.