### PR TITLE
Remove old references from Crypter.CryptoLib.csproj

### DIFF
--- a/Crypter.CryptoLib/Crypter.CryptoLib.csproj
+++ b/Crypter.CryptoLib/Crypter.CryptoLib.csproj
@@ -1,14 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Remove="Crypto\EllipticalCurve\**" />
-    <EmbeddedResource Remove="Crypto\EllipticalCurve\**" />
-    <None Remove="Crypto\EllipticalCurve\**" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />


### PR DESCRIPTION
While trying to figure out why I could not build Crypter.CryptoLib locally, I notice the project file contained some references to directories which do not exist.  Deleted the references.