### PR TITLE
Implement SimpleCryptoServices and CancellationTokens

### DIFF
--- a/Crypter.API/Controllers/MetricsController.cs
+++ b/Crypter.API/Controllers/MetricsController.cs
@@ -29,6 +29,7 @@ using Crypter.Core.Interfaces;
 using Crypter.Core.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.API.Controllers
@@ -51,10 +52,10 @@ namespace Crypter.API.Controllers
       }
 
       [HttpGet("disk")]
-      public async Task<IActionResult> GetDiskMetrics()
+      public async Task<IActionResult> GetDiskMetrics(CancellationToken cancellationToken)
       {
-         var sizeOfFileUploads = await _fileService.GetAggregateSizeAsync();
-         var sizeOfMessageUploads = await _messageService.GetAggregateSizeAsync();
+         var sizeOfFileUploads = await _fileService.GetAggregateSizeAsync(cancellationToken);
+         var sizeOfMessageUploads = await _messageService.GetAggregateSizeAsync(cancellationToken);
          var totalSizeOfUploads = sizeOfFileUploads + sizeOfMessageUploads;
          var isFull = totalSizeOfUploads + (10 * 1024 * 1024) >= AllocatedDiskSpace;
 

--- a/Crypter.API/Controllers/TransferController.cs
+++ b/Crypter.API/Controllers/TransferController.cs
@@ -29,9 +29,11 @@ using Crypter.API.Services;
 using Crypter.Contracts.Requests;
 using Crypter.Core.Interfaces;
 using Crypter.Core.Models;
+using Crypter.CryptoLib.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.API.Controllers
@@ -48,81 +50,83 @@ namespace Crypter.API.Controllers
           IUserService userService,
           IUserProfileService userProfileService,
           IEmailService emailService,
-          IApiValidationService apiValidationService
+          IApiValidationService apiValidationService,
+          ISimpleEncryptionService simpleEncryptionService,
+          ISimpleHashService simpleHashService
          )
       {
-         UploadService = new UploadService(configuration, messageService, fileService, emailService, apiValidationService);
-         DownloadService = new DownloadService(configuration, messageService, fileService, userService, userProfileService);
+         UploadService = new UploadService(configuration, messageService, fileService, emailService, apiValidationService, simpleEncryptionService, simpleHashService);
+         DownloadService = new DownloadService(configuration, messageService, fileService, userService, userProfileService, simpleEncryptionService, simpleHashService);
       }
 
       [HttpPost("message")]
-      public async Task<IActionResult> MessageTransferAsync([FromBody] MessageTransferRequest request)
+      public async Task<IActionResult> MessageTransferAsync([FromBody] MessageTransferRequest request, CancellationToken cancellationToken)
       {
          var senderId = ClaimsParser.ParseUserId(User);
-         return await UploadService.ReceiveMessageTransferAsync(request, senderId, Guid.Empty);
+         return await UploadService.ReceiveMessageTransferAsync(request, senderId, Guid.Empty, cancellationToken);
       }
 
       [HttpPost("message/{recipientId}")]
-      public async Task<IActionResult> UserMessageTransferAsync([FromBody] MessageTransferRequest request, Guid recipientId)
+      public async Task<IActionResult> UserMessageTransferAsync([FromBody] MessageTransferRequest request, Guid recipientId, CancellationToken cancellationToken)
       {
          var senderId = ClaimsParser.ParseUserId(User);
-         return await UploadService.ReceiveMessageTransferAsync(request, senderId, recipientId);
+         return await UploadService.ReceiveMessageTransferAsync(request, senderId, recipientId, cancellationToken);
       }
 
       [HttpPost("file")]
-      public async Task<IActionResult> FileTransferAsync([FromBody] FileTransferRequest request)
+      public async Task<IActionResult> FileTransferAsync([FromBody] FileTransferRequest request, CancellationToken cancellationToken)
       {
          var senderId = ClaimsParser.ParseUserId(User);
-         return await UploadService.ReceiveFileTransferAsync(request, senderId, Guid.Empty);
+         return await UploadService.ReceiveFileTransferAsync(request, senderId, Guid.Empty, cancellationToken);
       }
 
       [HttpPost("file/{recipientId}")]
-      public async Task<IActionResult> UserFileTransferAsync([FromBody] FileTransferRequest request, Guid recipientId)
+      public async Task<IActionResult> UserFileTransferAsync([FromBody] FileTransferRequest request, Guid recipientId, CancellationToken cancellationToken)
       {
          var senderId = ClaimsParser.ParseUserId(User);
-         return await UploadService.ReceiveFileTransferAsync(request, senderId, recipientId);
+         return await UploadService.ReceiveFileTransferAsync(request, senderId, recipientId, cancellationToken);
       }
 
       [HttpPost("message/preview")]
-      public async Task<IActionResult> GetMessagePreviewAsync([FromBody] GetTransferPreviewRequest request)
+      public async Task<IActionResult> GetMessagePreviewAsync([FromBody] GetTransferPreviewRequest request, CancellationToken cancellationToken)
       {
          var requestorId = ClaimsParser.ParseUserId(User);
-         return await DownloadService.GetMessagePreviewAsync(request, requestorId);
+         return await DownloadService.GetMessagePreviewAsync(request, requestorId, cancellationToken);
       }
 
       [HttpPost("file/preview")]
-      public async Task<IActionResult> GetFilePreviewAsync([FromBody] GetTransferPreviewRequest request)
+      public async Task<IActionResult> GetFilePreviewAsync([FromBody] GetTransferPreviewRequest request, CancellationToken cancellationToken)
       {
          var requestorId = ClaimsParser.ParseUserId(User);
-         return await DownloadService.GetFilePreviewAsync(request, requestorId);
+         return await DownloadService.GetFilePreviewAsync(request, requestorId, cancellationToken);
       }
 
       [HttpPost("message/ciphertext")]
-      public async Task<IActionResult> GetMessageCiphertextAsync([FromBody] GetTransferCiphertextRequest request)
+      public async Task<IActionResult> GetMessageCiphertextAsync([FromBody] GetTransferCiphertextRequest request, CancellationToken cancellationToken)
       {
          var requestorId = ClaimsParser.ParseUserId(User);
-         return await DownloadService.GetMessageCiphertextAsync(request, requestorId);
+         return await DownloadService.GetMessageCiphertextAsync(request, requestorId, cancellationToken);
       }
 
       [HttpPost("file/ciphertext")]
-      public async Task<IActionResult> GetFileCiphertext([FromBody] GetTransferCiphertextRequest request)
+      public async Task<IActionResult> GetFileCiphertext([FromBody] GetTransferCiphertextRequest request, CancellationToken cancellationToken)
       {
          var requestorId = ClaimsParser.ParseUserId(User);
-         return await DownloadService.GetFileCiphertextAsync(request, requestorId);
+         return await DownloadService.GetFileCiphertextAsync(request, requestorId, cancellationToken);
       }
 
       [HttpPost("message/signature")]
-      public async Task<IActionResult> GetMessageSignatureAsync([FromBody] GetTransferSignatureRequest request)
+      public async Task<IActionResult> GetMessageSignatureAsync([FromBody] GetTransferSignatureRequest request, CancellationToken cancellationToken)
       {
          var requestorId = ClaimsParser.ParseUserId(User);
-         return await DownloadService.GetMessageSignatureAsync(request, requestorId);
+         return await DownloadService.GetMessageSignatureAsync(request, requestorId, cancellationToken);
       }
 
       [HttpPost("file/signature")]
-      public async Task<IActionResult> GetFileSignatureAsync([FromBody] GetTransferSignatureRequest request)
+      public async Task<IActionResult> GetFileSignatureAsync([FromBody] GetTransferSignatureRequest request, CancellationToken cancellationToken)
       {
          var requestorId = ClaimsParser.ParseUserId(User);
-         return await DownloadService.GetFileSignatureAsync(request, requestorId);
+         return await DownloadService.GetFileSignatureAsync(request, requestorId, cancellationToken);
       }
    }
 }

--- a/Crypter.API/Controllers/UserController.cs
+++ b/Crypter.API/Controllers/UserController.cs
@@ -353,7 +353,7 @@ namespace Crypter.API.Controllers
 
          var user = await UserService.ReadAsync(userId, cancellationToken);
          if (ValidationService.IsPossibleEmailAddress(request.Email)
-            && user.Email.ToLower() != request.Email.ToLower()
+            && user.Email?.ToLower() != request.Email.ToLower()
             && !await UserService.IsEmailAddressAvailableAsync(request.Email, cancellationToken))
          {
             return new BadRequestObjectResult(

--- a/Crypter.API/Controllers/UserController.cs
+++ b/Crypter.API/Controllers/UserController.cs
@@ -46,6 +46,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.API.Controllers
@@ -100,19 +101,19 @@ namespace Crypter.API.Controllers
       }
 
       [HttpPost("register")]
-      public async Task<IActionResult> RegisterAsync([FromBody] RegisterUserRequest request)
+      public async Task<IActionResult> RegisterAsync([FromBody] RegisterUserRequest request, CancellationToken cancellationToken)
       {
-         var validationResult = await ApiValidationService.IsValidUserRegistrationRequest(request);
+         var validationResult = await ApiValidationService.IsValidUserRegistrationRequestAsync(request, cancellationToken);
          if (validationResult != InsertUserResult.Success)
          {
             return new BadRequestObjectResult(
                new UserRegisterResponse(validationResult));
          }
 
-         var userId = await UserService.InsertAsync(request.Username, request.Password, request.Email);
+         var userId = await UserService.InsertAsync(request.Username, request.Password, request.Email, cancellationToken);
 
-         await UserProfileService.UpsertAsync(userId, null, null);
-         await UserPrivacySettingService.UpsertAsync(userId, false, UserVisibilityLevel.None, UserItemTransferPermission.None, UserItemTransferPermission.None);
+         await UserProfileService.UpsertAsync(userId, null, null, default);
+         await UserPrivacySettingService.UpsertAsync(userId, false, UserVisibilityLevel.None, UserItemTransferPermission.None, UserItemTransferPermission.None, default);
 
          if (ValidationService.IsPossibleEmailAddress(request.Email))
          {
@@ -123,9 +124,9 @@ namespace Crypter.API.Controllers
       }
 
       [HttpPost("authenticate")]
-      public async Task<IActionResult> AuthenticateAsync([FromBody] AuthenticateUserRequest request)
+      public async Task<IActionResult> AuthenticateAsync([FromBody] AuthenticateUserRequest request, CancellationToken cancellationToken)
       {
-         var user = await UserService.AuthenticateAsync(request.Username, request.Password);
+         var user = await UserService.AuthenticateAsync(request.Username, request.Password, cancellationToken);
          if (user == null)
          {
             return new NotFoundObjectResult(
@@ -147,10 +148,10 @@ namespace Crypter.API.Controllers
          var token = tokenHandler.CreateToken(tokenDescriptor);
          var tokenString = tokenHandler.WriteToken(token);
 
-         var userX25519KeyPair = await UserX25519KeyPairService.GetUserPublicKeyPairAsync(user.Id);
-         var userEd25519KeyPair = await UserEd25519KeyPairService.GetUserPublicKeyPairAsync(user.Id);
+         var userX25519KeyPair = await UserX25519KeyPairService.GetUserPublicKeyPairAsync(user.Id, cancellationToken);
+         var userEd25519KeyPair = await UserEd25519KeyPairService.GetUserPublicKeyPairAsync(user.Id, cancellationToken);
 
-         BackgroundJob.Enqueue(() => UserService.UpdateLastLoginTime(user.Id, DateTime.UtcNow));
+         BackgroundJob.Enqueue(() => UserService.UpdateLastLoginTime(user.Id, DateTime.UtcNow, default));
 
          return new OkObjectResult(
              new UserAuthenticateResponse(user.Id, tokenString, userX25519KeyPair?.PrivateKey, userEd25519KeyPair?.PrivateKey, userX25519KeyPair?.ClientIV, userEd25519KeyPair?.ClientIV)
@@ -159,7 +160,7 @@ namespace Crypter.API.Controllers
 
       [Authorize]
       [HttpGet("authenticate/refresh")]
-      public IActionResult RefreshAuthenticationAsync()
+      public IActionResult RefreshAuthenticationAsync(CancellationToken cancellationToken)
       {
          var userId = ClaimsParser.ParseUserId(User);
 
@@ -178,7 +179,7 @@ namespace Crypter.API.Controllers
          var token = tokenHandler.CreateToken(tokenDescriptor);
          var tokenString = tokenHandler.WriteToken(token);
 
-         BackgroundJob.Enqueue(() => UserService.UpdateLastLoginTime(userId, DateTime.UtcNow));
+         BackgroundJob.Enqueue(() => UserService.UpdateLastLoginTime(userId, DateTime.UtcNow, cancellationToken));
 
          return new OkObjectResult(
             new UserAuthenticationRefreshResponse(tokenString));
@@ -186,11 +187,11 @@ namespace Crypter.API.Controllers
 
       [Authorize]
       [HttpGet("sent/messages")]
-      public async Task<IActionResult> GetSentMessagesAsync()
+      public async Task<IActionResult> GetSentMessagesAsync(CancellationToken cancellationToken)
       {
          var userId = ClaimsParser.ParseUserId(User);
 
-         var sentMessagesSansRecipientInfo = (await MessageService.FindBySenderAsync(userId))
+         var sentMessagesSansRecipientInfo = (await MessageService.FindBySenderAsync(userId, cancellationToken))
             .Select(x => new { x.Id, x.Subject, x.Recipient, x.Expiration })
             .OrderBy(x => x.Expiration);
 
@@ -201,8 +202,8 @@ namespace Crypter.API.Controllers
             IUserProfile recipientProfile = null;
             if (item.Recipient != Guid.Empty)
             {
-               recipient = await UserService.ReadAsync(item.Recipient);
-               recipientProfile = await UserProfileService.ReadAsync(item.Recipient);
+               recipient = await UserService.ReadAsync(item.Recipient, cancellationToken);
+               recipientProfile = await UserProfileService.ReadAsync(item.Recipient, cancellationToken);
             }
             sentMessages.Add(new UserSentMessageDTO(item.Id, item.Subject, item.Recipient, recipient?.Username, recipientProfile?.Alias, item.Expiration));
          }
@@ -213,11 +214,11 @@ namespace Crypter.API.Controllers
 
       [Authorize]
       [HttpGet("sent/files")]
-      public async Task<IActionResult> GetSentFilesAsync()
+      public async Task<IActionResult> GetSentFilesAsync(CancellationToken cancellationToken)
       {
          var userId = ClaimsParser.ParseUserId(User);
 
-         var sentFilesSansRecipientInfo = (await FileService.FindBySenderAsync(userId))
+         var sentFilesSansRecipientInfo = (await FileService.FindBySenderAsync(userId, cancellationToken))
             .Select(x => new { x.Id, x.FileName, x.Recipient, x.Expiration })
             .OrderBy(x => x.Expiration);
 
@@ -228,8 +229,8 @@ namespace Crypter.API.Controllers
             IUserProfile recipientProfile = null;
             if (item.Recipient != Guid.Empty)
             {
-               recipient = await UserService.ReadAsync(item.Recipient);
-               recipientProfile = await UserProfileService.ReadAsync(item.Recipient);
+               recipient = await UserService.ReadAsync(item.Recipient, cancellationToken);
+               recipientProfile = await UserProfileService.ReadAsync(item.Recipient, cancellationToken);
             }
             sentFiles.Add(new UserSentFileDTO(item.Id, item.FileName, item.Recipient, recipient?.Username, recipientProfile?.Alias, item.Expiration));
          }
@@ -240,11 +241,11 @@ namespace Crypter.API.Controllers
 
       [Authorize]
       [HttpGet("received/messages")]
-      public async Task<IActionResult> GetReceivedMessagesAsync()
+      public async Task<IActionResult> GetReceivedMessagesAsync(CancellationToken cancellationToken)
       {
          var userId = ClaimsParser.ParseUserId(User);
 
-         var receivedMessagesSansSenderInfo = (await MessageService.FindByRecipientAsync(userId))
+         var receivedMessagesSansSenderInfo = (await MessageService.FindByRecipientAsync(userId, cancellationToken))
             .Select(x => new { x.Id, x.Subject, x.Sender, x.Expiration })
             .OrderBy(x => x.Expiration);
 
@@ -255,8 +256,8 @@ namespace Crypter.API.Controllers
             IUserProfile senderProfile = null;
             if (item.Sender != Guid.Empty)
             {
-               sender = await UserService.ReadAsync(item.Sender);
-               senderProfile = await UserProfileService.ReadAsync(item.Sender);
+               sender = await UserService.ReadAsync(item.Sender, cancellationToken);
+               senderProfile = await UserProfileService.ReadAsync(item.Sender, cancellationToken);
             }
             receivedMessages.Add(new UserReceivedMessageDTO(item.Id, item.Subject, item.Sender, sender?.Username, senderProfile?.Alias, item.Expiration));
          }
@@ -267,11 +268,11 @@ namespace Crypter.API.Controllers
 
       [Authorize]
       [HttpGet("received/files")]
-      public async Task<IActionResult> GetReceivedFilesAsync()
+      public async Task<IActionResult> GetReceivedFilesAsync(CancellationToken cancellationToken)
       {
          var userId = ClaimsParser.ParseUserId(User);
 
-         var receivedFilesSansSenderInfo = (await FileService.FindByRecipientAsync(userId))
+         var receivedFilesSansSenderInfo = (await FileService.FindByRecipientAsync(userId, cancellationToken))
             .Select(x => new { x.Id, x.FileName, x.Sender, x.Expiration })
             .OrderBy(x => x.Expiration);
 
@@ -282,8 +283,8 @@ namespace Crypter.API.Controllers
             IUserProfile senderProfile = null;
             if (item.Sender != Guid.Empty)
             {
-               sender = await UserService.ReadAsync(item.Sender);
-               senderProfile = await UserProfileService.ReadAsync(item.Sender);
+               sender = await UserService.ReadAsync(item.Sender, cancellationToken);
+               senderProfile = await UserProfileService.ReadAsync(item.Sender, cancellationToken);
             }
             receivedFiles.Add(new UserReceivedFileDTO(item.Id, item.FileName, item.Sender, sender?.Username, senderProfile?.Alias, item.Expiration));
          }
@@ -294,13 +295,13 @@ namespace Crypter.API.Controllers
 
       [Authorize]
       [HttpGet("settings")]
-      public async Task<IActionResult> GetUserSettingsAsync()
+      public async Task<IActionResult> GetUserSettingsAsync(CancellationToken cancellationToken)
       {
          var userId = ClaimsParser.ParseUserId(User);
-         var user = await UserService.ReadAsync(userId);
-         var userProfile = await UserProfileService.ReadAsync(userId);
-         var userPrivacy = await UserPrivacySettingService.ReadAsync(userId);
-         var userNotification = await UserNotificationSettingService.ReadAsync(userId);
+         var user = await UserService.ReadAsync(userId, cancellationToken);
+         var userProfile = await UserProfileService.ReadAsync(userId, cancellationToken);
+         var userPrivacy = await UserPrivacySettingService.ReadAsync(userId, cancellationToken);
+         var userNotification = await UserNotificationSettingService.ReadAsync(userId, cancellationToken);
 
          return new OkObjectResult(
             new UserSettingsResponse(
@@ -321,10 +322,10 @@ namespace Crypter.API.Controllers
 
       [Authorize]
       [HttpPost("settings/profile")]
-      public async Task<IActionResult> UpdateUserProfileAsync([FromBody] UpdateProfileRequest request)
+      public async Task<IActionResult> UpdateUserProfileAsync([FromBody] UpdateProfileRequest request, CancellationToken cancellationToken)
       {
          var userId = ClaimsParser.ParseUserId(User);
-         var updateResult = await UserProfileService.UpsertAsync(userId, request.Alias, request.About);
+         var updateResult = await UserProfileService.UpsertAsync(userId, request.Alias, request.About, cancellationToken);
          var responseObject = new UpdateProfileResponse();
 
          if (updateResult)
@@ -339,7 +340,7 @@ namespace Crypter.API.Controllers
 
       [Authorize]
       [HttpPost("settings/contact")]
-      public async Task<IActionResult> UpdateUserContactInfoAsync([FromBody] UpdateContactInfoRequest request)
+      public async Task<IActionResult> UpdateUserContactInfoAsync([FromBody] UpdateContactInfoRequest request, CancellationToken cancellationToken)
       {
          var userId = ClaimsParser.ParseUserId(User);
 
@@ -350,16 +351,16 @@ namespace Crypter.API.Controllers
                new UpdateContactInfoResponse(UpdateContactInfoResult.EmailInvalid));
          }
 
-         var user = await UserService.ReadAsync(userId);
+         var user = await UserService.ReadAsync(userId, cancellationToken);
          if (ValidationService.IsPossibleEmailAddress(request.Email)
             && user.Email.ToLower() != request.Email.ToLower()
-            && !await UserService.IsEmailAddressAvailableAsync(request.Email))
+            && !await UserService.IsEmailAddressAvailableAsync(request.Email, cancellationToken))
          {
             return new BadRequestObjectResult(
                new UpdateContactInfoResponse(UpdateContactInfoResult.EmailUnavailable));
          }
 
-         var updateContactInfoResult = await UserService.UpdateContactInfoAsync(userId, request.Email, request.CurrentPassword);
+         var updateContactInfoResult = await UserService.UpdateContactInfoAsync(userId, request.Email, request.CurrentPassword, cancellationToken);
 
          if (updateContactInfoResult != UpdateContactInfoResult.Success)
          {
@@ -367,8 +368,8 @@ namespace Crypter.API.Controllers
             return new BadRequestObjectResult(responseObject);
          }
 
-         await UserNotificationSettingService.UpsertAsync(userId, false, false);
-         await UserEmailVerificationService.DeleteAsync(userId);
+         await UserNotificationSettingService.UpsertAsync(userId, false, false, default);
+         await UserEmailVerificationService.DeleteAsync(userId, default);
 
          if (ValidationService.IsValidEmailAddress(request.Email))
          {
@@ -381,10 +382,10 @@ namespace Crypter.API.Controllers
 
       [Authorize]
       [HttpPost("settings/notification")]
-      public async Task<IActionResult> UpdateUserNotificationPreferencesAsync([FromBody] UpdateNotificationSettingRequest request)
+      public async Task<IActionResult> UpdateUserNotificationPreferencesAsync([FromBody] UpdateNotificationSettingRequest request, CancellationToken cancellationToken)
       {
          var userId = ClaimsParser.ParseUserId(User);
-         var user = await UserService.ReadAsync(userId);
+         var user = await UserService.ReadAsync(userId, cancellationToken);
 
          if (request.EnableTransferNotifications
             && request.EmailNotifications
@@ -393,16 +394,16 @@ namespace Crypter.API.Controllers
             return new BadRequestObjectResult(new UpdateNotificationSettingResponse(UpdateUserNotificationSettingResult.EmailAddressNotVerified));
          }
 
-         await UserNotificationSettingService.UpsertAsync(userId, request.EnableTransferNotifications, request.EmailNotifications);
+         await UserNotificationSettingService.UpsertAsync(userId, request.EnableTransferNotifications, request.EmailNotifications, cancellationToken);
          return new OkObjectResult(new UpdateNotificationSettingResponse(UpdateUserNotificationSettingResult.Success));
       }
 
       [Authorize]
       [HttpPost("settings/privacy")]
-      public async Task<IActionResult> UpdateUserPrivacyAsync([FromBody] UpdatePrivacySettingRequest request)
+      public async Task<IActionResult> UpdateUserPrivacyAsync([FromBody] UpdatePrivacySettingRequest request, CancellationToken cancellationToken)
       {
          var userId = ClaimsParser.ParseUserId(User);
-         var updateSuccess = await UserPrivacySettingService.UpsertAsync(userId, request.AllowKeyExchangeRequests, request.VisibilityLevel, request.FileTransferPermission, request.MessageTransferPermission);
+         var updateSuccess = await UserPrivacySettingService.UpsertAsync(userId, request.AllowKeyExchangeRequests, request.VisibilityLevel, request.FileTransferPermission, request.MessageTransferPermission, cancellationToken);
 
          if (updateSuccess)
          {
@@ -416,11 +417,11 @@ namespace Crypter.API.Controllers
 
       [Authorize]
       [HttpPost("settings/keys/x25519")]
-      public async Task<IActionResult> UpdateDiffieHellmanKeysAsync([FromBody] UpdateKeysRequest body)
+      public async Task<IActionResult> UpdateDiffieHellmanKeysAsync([FromBody] UpdateKeysRequest body, CancellationToken cancellationToken)
       {
          var userId = ClaimsParser.ParseUserId(User);
 
-         var insertResult = await UserX25519KeyPairService.InsertUserPublicKeyPairAsync(userId, body.EncryptedPrivateKeyBase64, body.PublicKeyBase64, body.ClientIVBase64);
+         var insertResult = await UserX25519KeyPairService.InsertUserPublicKeyPairAsync(userId, body.EncryptedPrivateKeyBase64, body.PublicKeyBase64, body.ClientIVBase64, cancellationToken);
          if (insertResult)
          {
             return new OkObjectResult(
@@ -435,11 +436,11 @@ namespace Crypter.API.Controllers
 
       [Authorize]
       [HttpPost("settings/keys/ed25519")]
-      public async Task<IActionResult> UpdateDigitalSignatureKeysAsync([FromBody] UpdateKeysRequest body)
+      public async Task<IActionResult> UpdateDigitalSignatureKeysAsync([FromBody] UpdateKeysRequest body, CancellationToken cancellationToken)
       {
          var userId = ClaimsParser.ParseUserId(User);
 
-         var insertResult = await UserEd25519KeyPairService.InsertUserPublicKeyPairAsync(userId, body.EncryptedPrivateKeyBase64, body.PublicKeyBase64, body.ClientIVBase64);
+         var insertResult = await UserEd25519KeyPairService.InsertUserPublicKeyPairAsync(userId, body.EncryptedPrivateKeyBase64, body.PublicKeyBase64, body.ClientIVBase64, cancellationToken);
          if (insertResult)
          {
             return new OkObjectResult(
@@ -454,10 +455,10 @@ namespace Crypter.API.Controllers
 
       [Authorize]
       [HttpGet("search/username")]
-      public async Task<IActionResult> SearchByUsernameAsync([FromQuery] string value, [FromQuery] int index, [FromQuery] int count)
+      public async Task<IActionResult> SearchByUsernameAsync([FromQuery] string value, [FromQuery] int index, [FromQuery] int count, CancellationToken cancellationToken)
       {
          var searchPartyId = ClaimsParser.ParseUserId(User);
-         var (total, users) = await UserSearchService.SearchByUsernameAsync(searchPartyId, value, index, count);
+         var (total, users) = await UserSearchService.SearchByUsernameAsync(searchPartyId, value, index, count, cancellationToken);
          var dtoUsers = users
              .Select(x => new UserSearchResultDTO(x.Id, x.Username, x.Alias))
              .ToList();
@@ -468,10 +469,10 @@ namespace Crypter.API.Controllers
 
       [Authorize]
       [HttpGet("search/alias")]
-      public async Task<IActionResult> SearchByAliasAsync([FromQuery] string value, [FromQuery] int index, [FromQuery] int count)
+      public async Task<IActionResult> SearchByAliasAsync([FromQuery] string value, [FromQuery] int index, [FromQuery] int count, CancellationToken cancellationToken)
       {
          var searchPartyId = ClaimsParser.ParseUserId(User);
-         var (total, users) = await UserSearchService.SearchByAliasAsync(searchPartyId, value, index, count);
+         var (total, users) = await UserSearchService.SearchByAliasAsync(searchPartyId, value, index, count, cancellationToken);
          var dtoUsers = users
              .Select(x => new UserSearchResultDTO(x.Id, x.Username, x.Alias))
              .ToList();
@@ -481,38 +482,38 @@ namespace Crypter.API.Controllers
       }
 
       [HttpGet("{username}")]
-      public async Task<IActionResult> GetPublicUserProfileAsync(string username)
+      public async Task<IActionResult> GetPublicUserProfileAsync(string username, CancellationToken cancellationToken)
       {
          var visitorId = ClaimsParser.ParseUserId(User);
          var notFoundResponse = new UserPublicProfileResponse(default, null, null, null, false, false, false, false, null, null);
 
          var requestor = ClaimsParser.ParseUserId(User);
-         var user = await UserService.ReadAsync(username);
+         var user = await UserService.ReadAsync(username, cancellationToken);
          if (user is null)
          {
             return new NotFoundObjectResult(notFoundResponse);
          }
 
-         var userProfile = await UserProfileService.ReadAsync(user.Id);
+         var userProfile = await UserProfileService.ReadAsync(user.Id, cancellationToken);
          if (userProfile is null)
          {
             return new NotFoundObjectResult(notFoundResponse);
          }
 
-         var userPrivacy = await UserPrivacySettingService.ReadAsync(user.Id);
+         var userPrivacy = await UserPrivacySettingService.ReadAsync(user.Id, cancellationToken);
          if (userPrivacy is null)
          {
             return new NotFoundObjectResult(notFoundResponse);
          }
 
-         var userAllowsRequestorToViewProfile = await UserPrivacySettingService.IsUserViewableByPartyAsync(user.Id, requestor);
+         var userAllowsRequestorToViewProfile = await UserPrivacySettingService.IsUserViewableByPartyAsync(user.Id, requestor, cancellationToken);
          if (userAllowsRequestorToViewProfile)
          {
-            var userPublicDHKey = await UserX25519KeyPairService.GetUserPublicKeyAsync(user.Id);
-            var userPublicDSAKey = await UserEd25519KeyPairService.GetUserPublicKeyAsync(user.Id);
+            var userPublicDHKey = await UserX25519KeyPairService.GetUserPublicKeyAsync(user.Id, cancellationToken);
+            var userPublicDSAKey = await UserEd25519KeyPairService.GetUserPublicKeyAsync(user.Id, cancellationToken);
 
-            var visitorCanSendMessages = await UserPrivacySettingService.DoesUserAcceptMessagesFromOtherPartyAsync(user.Id, visitorId);
-            var visitorCanSendFiles = await UserPrivacySettingService.DoesUserAcceptFilesFromOtherPartyAsync(user.Id, visitorId);
+            var visitorCanSendMessages = await UserPrivacySettingService.DoesUserAcceptMessagesFromOtherPartyAsync(user.Id, visitorId, cancellationToken);
+            var visitorCanSendFiles = await UserPrivacySettingService.DoesUserAcceptFilesFromOtherPartyAsync(user.Id, visitorId, cancellationToken);
 
             return new OkObjectResult(
                new UserPublicProfileResponse(user.Id, user.Username, userProfile.Alias, userProfile.About, userPrivacy.AllowKeyExchangeRequests,
@@ -525,11 +526,11 @@ namespace Crypter.API.Controllers
       }
 
       [HttpPost("verify")]
-      public async Task<IActionResult> VerifyUserEmailAddressAsync([FromBody] VerifyUserEmailAddressRequest request)
+      public async Task<IActionResult> VerifyUserEmailAddressAsync([FromBody] VerifyUserEmailAddressRequest request, CancellationToken cancellationToken)
       {
          var verificationCode = EmailVerificationEncoder.DecodeVerificationCodeFromUrlSafe(request.Code);
 
-         var emailVerificationEntity = await UserEmailVerificationService.ReadCodeAsync(verificationCode);
+         var emailVerificationEntity = await UserEmailVerificationService.ReadCodeAsync(verificationCode, cancellationToken);
          if (emailVerificationEntity is null)
          {
             return new NotFoundObjectResult(
@@ -550,8 +551,8 @@ namespace Crypter.API.Controllers
                new UserEmailVerificationResponse(false));
          }
 
-         await UserService.UpdateEmailAddressVerification(emailVerificationEntity.Owner, true);
-         await UserEmailVerificationService.DeleteAsync(emailVerificationEntity.Owner);
+         await UserService.UpdateEmailAddressVerification(emailVerificationEntity.Owner, true, default);
+         await UserEmailVerificationService.DeleteAsync(emailVerificationEntity.Owner, default);
 
          return new OkObjectResult(
             new UserEmailVerificationResponse(true));

--- a/Crypter.API/Services/EmailService.cs
+++ b/Crypter.API/Services/EmailService.cs
@@ -166,8 +166,8 @@ namespace Crypter.API.Services
       /// <returns></returns>
       public async Task HangfireSendEmailVerificationAsync(Guid userId)
       {
-         var userEntity = await UserService.ReadAsync(userId);
-         var userEmailVerificationEntity = await UserEmailVerificationService.ReadAsync(userId);
+         var userEntity = await UserService.ReadAsync(userId, default);
+         var userEmailVerificationEntity = await UserEmailVerificationService.ReadAsync(userId, default);
 
          if (userEntity == null                                         // User does not exist
             || !ValidationService.IsValidEmailAddress(userEntity.Email) // User does not have a valid email address
@@ -183,7 +183,7 @@ namespace Crypter.API.Services
          var success = await SendEmailVerificationAsync(userEntity.Email, verificationCode, keys.Private);
          if (success)
          {
-            await UserEmailVerificationService.InsertAsync(userId, verificationCode, Encoding.UTF8.GetBytes(keys.Public.ConvertToPEM()));
+            await UserEmailVerificationService.InsertAsync(userId, verificationCode, Encoding.UTF8.GetBytes(keys.Public.ConvertToPEM()), default);
          }
       }
 
@@ -199,7 +199,7 @@ namespace Crypter.API.Services
          switch (itemType)
          {
             case TransferItemType.Message:
-               var message = await MessageTransferService.ReadAsync(itemId);
+               var message = await MessageTransferService.ReadAsync(itemId, default);
                if (message is null)
                {
                   return;
@@ -208,7 +208,7 @@ namespace Crypter.API.Services
                recipientId = message.Recipient;
                break;
             case TransferItemType.File:
-               var file = await FileTransferService.ReadAsync(itemId);
+               var file = await FileTransferService.ReadAsync(itemId, default);
                if (file is null)
                {
                   return;
@@ -220,7 +220,7 @@ namespace Crypter.API.Services
                return;
          }
 
-         var user = await UserService.ReadAsync(recipientId);
+         var user = await UserService.ReadAsync(recipientId, default);
          if (user is null
             || !user.EmailVerified
             || !ValidationService.IsValidEmailAddress(user.Email))
@@ -228,7 +228,7 @@ namespace Crypter.API.Services
             return;
          }
 
-         var userNotification = await UserNotificationSettingService.ReadAsync(recipientId);
+         var userNotification = await UserNotificationSettingService.ReadAsync(recipientId, default);
          if (userNotification is null
             || !userNotification.EnableTransferNotifications
             || !userNotification.EmailNotifications)

--- a/Crypter.API/Startup.cs
+++ b/Crypter.API/Startup.cs
@@ -30,6 +30,7 @@ using Crypter.Core;
 using Crypter.Core.Interfaces;
 using Crypter.Core.Models;
 using Crypter.Core.Services.DataAccess;
+using Crypter.CryptoLib.Services;
 using Hangfire;
 using Hangfire.PostgreSql;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -70,9 +71,11 @@ namespace CrypterAPI
          services.AddScoped<IBaseTransferService<MessageTransfer>, MessageTransferItemService>();
          services.AddScoped<IBaseTransferService<FileTransfer>, FileTransferItemService>();
          services.AddScoped<ISchemaService, SchemaService>();
-
          services.AddScoped<IEmailService, EmailService>();
          services.AddScoped<IApiValidationService, ApiValidationService>();
+         services.AddScoped<ISimpleEncryptionService, SimpleEncryptionService>();
+         services.AddScoped<ISimpleHashService, SimpleHashService>();
+         services.AddScoped<ISimpleSignatureService, SimpleSignatureService>();
 
          services.AddHangfire(config =>
               config.UsePostgreSqlStorage(Configuration.GetConnectionString("HangfireConnection")));
@@ -151,7 +154,7 @@ namespace CrypterAPI
          var userService = context.HttpContext.RequestServices.GetRequiredService<IUserService>();
          var userIdFromJWT = ClaimsParser.ParseUserId(context.Principal);
 
-         var user = await userService.ReadAsync(userIdFromJWT);
+         var user = await userService.ReadAsync(userIdFromJWT, default);
          return user != null;
       }
    }

--- a/Crypter.Console/Jobs/DeleteExpired.cs
+++ b/Crypter.Console/Jobs/DeleteExpired.cs
@@ -54,21 +54,21 @@ namespace Crypter.Console.Jobs
          Logger.LogInformation($"{DateTime.Now:HH:mm:ss} DeleteExpired is working.");
 
          var messageStorageService = new TransferItemStorageService(FileStorePath, TransferItemType.Message);
-         var expiredMessages = await MessageService.FindExpiredAsync();
+         var expiredMessages = await MessageService.FindExpiredAsync(default);
          foreach (MessageTransfer expiredItem in expiredMessages)
          {
             Logger.LogInformation($"Deleting message {expiredItem.Id}");
-            await MessageService.DeleteAsync(expiredItem.Id);
+            await MessageService.DeleteAsync(expiredItem.Id, default);
             messageStorageService.Delete(expiredItem.Id);
             Logger.LogInformation($"Delete complete");
          }
 
          var fileStorageService = new TransferItemStorageService(FileStorePath, TransferItemType.File);
-         var expiredFiles = await FileService.FindExpiredAsync();
+         var expiredFiles = await FileService.FindExpiredAsync(default);
          foreach (FileTransfer expiredItem in expiredFiles)
          {
             Logger.LogInformation($"Deleting file {expiredItem.Id}");
-            await FileService.DeleteAsync(expiredItem.Id);
+            await FileService.DeleteAsync(expiredItem.Id, default);
             fileStorageService.Delete(expiredItem.Id);
             Logger.LogInformation($"Delete complete");
          }

--- a/Crypter.Core/Interfaces/DataService/IBaseTransferService.cs
+++ b/Crypter.Core/Interfaces/DataService/IBaseTransferService.cs
@@ -26,19 +26,20 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Interfaces
 {
    public interface IBaseTransferService<T>
    {
-      Task InsertAsync(T item);
-      Task<T> ReadAsync(Guid id);
-      Task DeleteAsync(Guid id);
+      Task InsertAsync(T item, CancellationToken cancellationToken);
+      Task<T> ReadAsync(Guid id, CancellationToken cancellationToken);
+      Task DeleteAsync(Guid id, CancellationToken cancellationToken);
 
-      Task<IEnumerable<T>> FindBySenderAsync(Guid senderId);
-      Task<IEnumerable<T>> FindByRecipientAsync(Guid recipientId);
-      Task<IEnumerable<T>> FindExpiredAsync();
-      Task<long> GetAggregateSizeAsync();
+      Task<IEnumerable<T>> FindBySenderAsync(Guid senderId, CancellationToken cancellationToken);
+      Task<IEnumerable<T>> FindByRecipientAsync(Guid recipientId, CancellationToken cancellationToken);
+      Task<IEnumerable<T>> FindExpiredAsync(CancellationToken cancellationToken);
+      Task<long> GetAggregateSizeAsync(CancellationToken cancellationToken);
    }
 }

--- a/Crypter.Core/Interfaces/DataService/ISchemaService.cs
+++ b/Crypter.Core/Interfaces/DataService/ISchemaService.cs
@@ -24,12 +24,13 @@
  * Contact the current copyright holder to discuss commerical license options.
  */
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Interfaces
 {
    public interface ISchemaService
    {
-      Task<ISchema> ReadAsync();
+      Task<ISchema> ReadAsync(CancellationToken cancellationToken);
    }
 }

--- a/Crypter.Core/Interfaces/DataService/ITransferItemStorageService.cs
+++ b/Crypter.Core/Interfaces/DataService/ITransferItemStorageService.cs
@@ -25,14 +25,15 @@
  */
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Interfaces
 {
    public interface ITransferItemStorageService
    {
-      Task<bool> SaveAsync(Guid id, byte[] data);
-      Task<byte[]> ReadAsync(Guid id);
+      Task<bool> SaveAsync(Guid id, byte[] data, CancellationToken cancellationToken);
+      Task<byte[]> ReadAsync(Guid id, CancellationToken cancellationToken);
       bool Delete(Guid id);
    }
 }

--- a/Crypter.Core/Interfaces/DataService/IUserEmailVerificationService.cs
+++ b/Crypter.Core/Interfaces/DataService/IUserEmailVerificationService.cs
@@ -25,15 +25,16 @@
  */
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Interfaces
 {
    public interface IUserEmailVerificationService
    {
-      Task<bool> InsertAsync(Guid userId, Guid code, byte[] verificationKey);
-      Task<IUserEmailVerification> ReadAsync(Guid userId);
-      Task<IUserEmailVerification> ReadCodeAsync(Guid code);
-      Task DeleteAsync(Guid userId);
+      Task<bool> InsertAsync(Guid userId, Guid code, byte[] verificationKey, CancellationToken cancellationToken);
+      Task<IUserEmailVerification> ReadAsync(Guid userId, CancellationToken cancellationToken);
+      Task<IUserEmailVerification> ReadCodeAsync(Guid code, CancellationToken cancellationToken);
+      Task DeleteAsync(Guid userId, CancellationToken cancellationToken);
    }
 }

--- a/Crypter.Core/Interfaces/DataService/IUserNotificationSettingService.cs
+++ b/Crypter.Core/Interfaces/DataService/IUserNotificationSettingService.cs
@@ -25,13 +25,14 @@
  */
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Interfaces
 {
    public interface IUserNotificationSettingService
    {
-      Task<IUserNotificationSetting> ReadAsync(Guid userId);
-      Task UpsertAsync(Guid userId, bool enableTransferNotifications, bool emailNotifications);
+      Task<IUserNotificationSetting> ReadAsync(Guid userId, CancellationToken cancellationToken);
+      Task UpsertAsync(Guid userId, bool enableTransferNotifications, bool emailNotifications, CancellationToken cancellationToken);
    }
 }

--- a/Crypter.Core/Interfaces/DataService/IUserPrivacySettingService.cs
+++ b/Crypter.Core/Interfaces/DataService/IUserPrivacySettingService.cs
@@ -26,17 +26,18 @@
 
 using Crypter.Contracts.Enum;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Interfaces
 {
    public interface IUserPrivacySettingService
    {
-      Task<bool> UpsertAsync(Guid userId, bool allowKeyExchangeRequests, UserVisibilityLevel visibilityLevel, UserItemTransferPermission receiveFilesPermission, UserItemTransferPermission receiveMessagesPermission);
-      Task<IUserPrivacySetting> ReadAsync(Guid userId);
+      Task<bool> UpsertAsync(Guid userId, bool allowKeyExchangeRequests, UserVisibilityLevel visibilityLevel, UserItemTransferPermission receiveFilesPermission, UserItemTransferPermission receiveMessagesPermission, CancellationToken cancellationToken);
+      Task<IUserPrivacySetting> ReadAsync(Guid userId, CancellationToken cancellationToken);
 
-      Task<bool> IsUserViewableByPartyAsync(Guid userId, Guid otherPartyId);
-      Task<bool> DoesUserAcceptMessagesFromOtherPartyAsync(Guid userId, Guid otherPartyId);
-      Task<bool> DoesUserAcceptFilesFromOtherPartyAsync(Guid userId, Guid otherPartyId);
+      Task<bool> IsUserViewableByPartyAsync(Guid userId, Guid otherPartyId, CancellationToken cancellationToken);
+      Task<bool> DoesUserAcceptMessagesFromOtherPartyAsync(Guid userId, Guid otherPartyId, CancellationToken cancellationToken);
+      Task<bool> DoesUserAcceptFilesFromOtherPartyAsync(Guid userId, Guid otherPartyId, CancellationToken cancellationToken);
    }
 }

--- a/Crypter.Core/Interfaces/DataService/IUserProfileService.cs
+++ b/Crypter.Core/Interfaces/DataService/IUserProfileService.cs
@@ -25,13 +25,14 @@
  */
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Interfaces
 {
    public interface IUserProfileService
    {
-      Task<IUserProfile> ReadAsync(Guid id);
-      Task<bool> UpsertAsync(Guid id, string alias, string about);
+      Task<IUserProfile> ReadAsync(Guid id, CancellationToken cancellationToken);
+      Task<bool> UpsertAsync(Guid id, string alias, string about, CancellationToken cancellationToken);
    }
 }

--- a/Crypter.Core/Interfaces/DataService/IUserPublicKeyPairService.cs
+++ b/Crypter.Core/Interfaces/DataService/IUserPublicKeyPairService.cs
@@ -25,14 +25,15 @@
  */
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Interfaces
 {
    public interface IUserPublicKeyPairService<T>
    {
-      Task<IUserPublicKeyPair> GetUserPublicKeyPairAsync(Guid userId);
-      Task<string> GetUserPublicKeyAsync(Guid userId);
-      Task<bool> InsertUserPublicKeyPairAsync(Guid userId, string privateKey, string publicKey, string clientIV);
+      Task<IUserPublicKeyPair> GetUserPublicKeyPairAsync(Guid userId, CancellationToken cancellationToken);
+      Task<string> GetUserPublicKeyAsync(Guid userId, CancellationToken cancellationToken);
+      Task<bool> InsertUserPublicKeyPairAsync(Guid userId, string privateKey, string publicKey, string clientIV, CancellationToken cancellationToken);
    }
 }

--- a/Crypter.Core/Interfaces/DataService/IUserSearchService.cs
+++ b/Crypter.Core/Interfaces/DataService/IUserSearchService.cs
@@ -27,13 +27,14 @@
 using Crypter.Contracts.DTO;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Interfaces
 {
    public interface IUserSearchService
    {
-      Task<(int total, IEnumerable<UserSearchResultDTO> users)> SearchByUsernameAsync(Guid searchParty, string query, int startingIndex, int count);
-      Task<(int total, IEnumerable<UserSearchResultDTO> users)> SearchByAliasAsync(Guid searchParty, string query, int startingIndex, int count);
+      Task<(int total, IEnumerable<UserSearchResultDTO> users)> SearchByUsernameAsync(Guid searchParty, string query, int startingIndex, int count, CancellationToken cancellationToken);
+      Task<(int total, IEnumerable<UserSearchResultDTO> users)> SearchByAliasAsync(Guid searchParty, string query, int startingIndex, int count, CancellationToken cancellationToken);
    }
 }

--- a/Crypter.Core/Services/DataAccess/FileTransferItemService.cs
+++ b/Crypter.Core/Services/DataAccess/FileTransferItemService.cs
@@ -30,6 +30,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Services.DataAccess
@@ -43,49 +44,49 @@ namespace Crypter.Core.Services.DataAccess
          Context = context;
       }
 
-      public async Task InsertAsync(FileTransfer item)
+      public async Task InsertAsync(FileTransfer item, CancellationToken cancellationToken)
       {
          Context.FileTransfer.Add(item);
-         await Context.SaveChangesAsync();
+         await Context.SaveChangesAsync(cancellationToken);
       }
 
-      public async Task<FileTransfer> ReadAsync(Guid id)
+      public async Task<FileTransfer> ReadAsync(Guid id, CancellationToken cancellationToken)
       {
          return await Context.FileTransfer
-             .FindAsync(id);
+             .FindAsync(new object[] { id }, cancellationToken);
       }
 
-      public async Task DeleteAsync(Guid id)
+      public async Task DeleteAsync(Guid id, CancellationToken cancellationToken)
       {
          await Context.Database
-             .ExecuteSqlRawAsync("DELETE FROM \"FileTransfer\" WHERE \"FileTransfer\".\"Id\" = {0}", id);
+             .ExecuteSqlRawAsync("DELETE FROM \"FileTransfer\" WHERE \"FileTransfer\".\"Id\" = {0}", new object[] { id }, cancellationToken);
       }
 
-      public async Task<IEnumerable<FileTransfer>> FindBySenderAsync(Guid senderId)
+      public async Task<IEnumerable<FileTransfer>> FindBySenderAsync(Guid senderId, CancellationToken cancellationToken)
       {
          return await Context.FileTransfer
              .Where(x => x.Sender == senderId)
-             .ToListAsync();
+             .ToListAsync(cancellationToken);
       }
 
-      public async Task<IEnumerable<FileTransfer>> FindByRecipientAsync(Guid recipientId)
+      public async Task<IEnumerable<FileTransfer>> FindByRecipientAsync(Guid recipientId, CancellationToken cancellationToken)
       {
          return await Context.FileTransfer
              .Where(x => x.Recipient == recipientId)
-             .ToListAsync();
+             .ToListAsync(cancellationToken);
       }
 
-      public async Task<IEnumerable<FileTransfer>> FindExpiredAsync()
+      public async Task<IEnumerable<FileTransfer>> FindExpiredAsync(CancellationToken cancellationToken)
       {
          return await Context.FileTransfer
              .Where(x => x.Expiration < DateTime.UtcNow)
-             .ToListAsync();
+             .ToListAsync(cancellationToken);
       }
 
-      public async Task<long> GetAggregateSizeAsync()
+      public async Task<long> GetAggregateSizeAsync(CancellationToken cancellationToken)
       {
          return await Context.FileTransfer
-             .SumAsync(x => x.Size);
+             .SumAsync(x => x.Size, cancellationToken);
       }
    }
 }

--- a/Crypter.Core/Services/DataAccess/MessageTransferItemService.cs
+++ b/Crypter.Core/Services/DataAccess/MessageTransferItemService.cs
@@ -30,6 +30,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Services.DataAccess
@@ -43,49 +44,49 @@ namespace Crypter.Core.Services.DataAccess
          Context = context;
       }
 
-      public async Task InsertAsync(MessageTransfer item)
+      public async Task InsertAsync(MessageTransfer item, CancellationToken cancellationToken)
       {
          Context.MessageTransfer.Add(item);
-         await Context.SaveChangesAsync();
+         await Context.SaveChangesAsync(cancellationToken);
       }
 
-      public async Task<MessageTransfer> ReadAsync(Guid id)
+      public async Task<MessageTransfer> ReadAsync(Guid id, CancellationToken cancellationToken)
       {
          return await Context.MessageTransfer
-             .FindAsync(id);
+             .FindAsync(new object[] { id }, cancellationToken);
       }
 
-      public async Task DeleteAsync(Guid id)
+      public async Task DeleteAsync(Guid id, CancellationToken cancellationToken)
       {
          await Context.Database
-             .ExecuteSqlRawAsync("DELETE FROM \"MessageTransfer\" WHERE \"MessageTransfer\".\"Id\" = {0}", id);
+             .ExecuteSqlRawAsync("DELETE FROM \"MessageTransfer\" WHERE \"MessageTransfer\".\"Id\" = {0}", new object[] { id }, cancellationToken);
       }
 
-      public async Task<IEnumerable<MessageTransfer>> FindBySenderAsync(Guid ownerId)
+      public async Task<IEnumerable<MessageTransfer>> FindBySenderAsync(Guid ownerId, CancellationToken cancellationToken)
       {
          return await Context.MessageTransfer
              .Where(x => x.Sender == ownerId)
-             .ToListAsync();
+             .ToListAsync(cancellationToken);
       }
 
-      public async Task<IEnumerable<MessageTransfer>> FindByRecipientAsync(Guid recipientId)
+      public async Task<IEnumerable<MessageTransfer>> FindByRecipientAsync(Guid recipientId, CancellationToken cancellationToken)
       {
          return await Context.MessageTransfer
              .Where(x => x.Recipient == recipientId)
-             .ToListAsync();
+             .ToListAsync(cancellationToken);
       }
 
-      public async Task<IEnumerable<MessageTransfer>> FindExpiredAsync()
+      public async Task<IEnumerable<MessageTransfer>> FindExpiredAsync(CancellationToken cancellationToken)
       {
          return await Context.MessageTransfer
              .Where(x => x.Expiration < DateTime.UtcNow)
-             .ToListAsync();
+             .ToListAsync(cancellationToken);
       }
 
-      public async Task<long> GetAggregateSizeAsync()
+      public async Task<long> GetAggregateSizeAsync(CancellationToken cancellationToken)
       {
          return await Context.MessageTransfer
-             .SumAsync(x => x.Size);
+             .SumAsync(x => x.Size, cancellationToken);
       }
    }
 }

--- a/Crypter.Core/Services/DataAccess/SchemaService.cs
+++ b/Crypter.Core/Services/DataAccess/SchemaService.cs
@@ -26,6 +26,7 @@
 
 using Crypter.Core.Interfaces;
 using Microsoft.EntityFrameworkCore;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Services.DataAccess
@@ -39,9 +40,9 @@ namespace Crypter.Core.Services.DataAccess
          Context = context;
       }
 
-      public async Task<ISchema> ReadAsync()
+      public async Task<ISchema> ReadAsync(CancellationToken cancellationToken)
       {
-         return await Context.Schema.FirstOrDefaultAsync();
+         return await Context.Schema.FirstOrDefaultAsync(cancellationToken);
       }
    }
 }

--- a/Crypter.Core/Services/DataAccess/UserEd25519KeyPairService.cs
+++ b/Crypter.Core/Services/DataAccess/UserEd25519KeyPairService.cs
@@ -29,6 +29,7 @@ using Crypter.Core.Models;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Services.DataAccess
@@ -42,24 +43,24 @@ namespace Crypter.Core.Services.DataAccess
          Context = context;
       }
 
-      public async Task<IUserPublicKeyPair> GetUserPublicKeyPairAsync(Guid userId)
+      public async Task<IUserPublicKeyPair> GetUserPublicKeyPairAsync(Guid userId, CancellationToken cancellationToken)
       {
          return await Context.UserEd25519KeyPair
              .Where(x => x.Owner == userId)
-             .FirstOrDefaultAsync();
+             .FirstOrDefaultAsync(cancellationToken);
       }
 
-      public async Task<string> GetUserPublicKeyAsync(Guid userId)
+      public async Task<string> GetUserPublicKeyAsync(Guid userId, CancellationToken cancellationToken)
       {
          var keyPair = await Context.UserEd25519KeyPair
              .Where(x => x.Owner == userId)
-             .FirstOrDefaultAsync();
+             .FirstOrDefaultAsync(cancellationToken);
          return keyPair?.PublicKey;
       }
 
-      public async Task<bool> InsertUserPublicKeyPairAsync(Guid userId, string privateKey, string publicKey, string clientIV)
+      public async Task<bool> InsertUserPublicKeyPairAsync(Guid userId, string privateKey, string publicKey, string clientIV, CancellationToken cancellationToken)
       {
-         if (await GetUserPublicKeyPairAsync(userId) != default(UserEd25519KeyPair))
+         if (await GetUserPublicKeyPairAsync(userId, cancellationToken) != default(UserEd25519KeyPair))
          {
             return false;
          }
@@ -73,7 +74,7 @@ namespace Crypter.Core.Services.DataAccess
              DateTime.UtcNow);
 
          Context.UserEd25519KeyPair.Add(key);
-         await Context.SaveChangesAsync();
+         await Context.SaveChangesAsync(cancellationToken);
          return true;
       }
    }

--- a/Crypter.Core/Services/DataAccess/UserEmailVerificationService.cs
+++ b/Crypter.Core/Services/DataAccess/UserEmailVerificationService.cs
@@ -29,6 +29,7 @@ using Crypter.Core.Models;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Services.DataAccess
@@ -42,30 +43,30 @@ namespace Crypter.Core.Services.DataAccess
          Context = context;
       }
 
-      public async Task<bool> InsertAsync(Guid userId, Guid code, byte[] verificationKey)
+      public async Task<bool> InsertAsync(Guid userId, Guid code, byte[] verificationKey, CancellationToken cancellationToken)
       {
          var emailVerification = new UserEmailVerification(userId, code, verificationKey, DateTime.UtcNow);
          Context.UserEmailVerification.Add(emailVerification);
-         await Context.SaveChangesAsync();
+         await Context.SaveChangesAsync(cancellationToken);
          return true;
       }
 
-      public async Task<IUserEmailVerification> ReadAsync(Guid userId)
+      public async Task<IUserEmailVerification> ReadAsync(Guid userId, CancellationToken cancellationToken)
       {
-         return await Context.UserEmailVerification.FindAsync(userId);
+         return await Context.UserEmailVerification.FindAsync(new object[] { userId }, cancellationToken);
       }
 
-      public async Task<IUserEmailVerification> ReadCodeAsync(Guid code)
+      public async Task<IUserEmailVerification> ReadCodeAsync(Guid code, CancellationToken cancellationToken)
       {
          return await Context.UserEmailVerification
             .Where(x => x.Code == code)
-            .FirstOrDefaultAsync();
+            .FirstOrDefaultAsync(cancellationToken);
       }
 
-      public async Task DeleteAsync(Guid userId)
+      public async Task DeleteAsync(Guid userId, CancellationToken cancellationToken)
       {
          await Context.Database
-             .ExecuteSqlRawAsync("DELETE FROM \"UserEmailVerification\" WHERE \"UserEmailVerification\".\"Owner\" = {0}", userId);
+             .ExecuteSqlRawAsync("DELETE FROM \"UserEmailVerification\" WHERE \"UserEmailVerification\".\"Owner\" = {0}", new object[] { userId }, cancellationToken);
       }
    }
 }

--- a/Crypter.Core/Services/DataAccess/UserNotificationSettingService.cs
+++ b/Crypter.Core/Services/DataAccess/UserNotificationSettingService.cs
@@ -27,6 +27,7 @@
 using Crypter.Core.Interfaces;
 using Crypter.Core.Models;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Services.DataAccess
@@ -40,9 +41,9 @@ namespace Crypter.Core.Services.DataAccess
          Context = context;
       }
 
-      public async Task UpsertAsync(Guid userId, bool enableTransferNotifications, bool emailNotifications)
+      public async Task UpsertAsync(Guid userId, bool enableTransferNotifications, bool emailNotifications, CancellationToken cancellationToken)
       {
-         var userNotificationSettings = await ReadAsync(userId);
+         var userNotificationSettings = await ReadAsync(userId, cancellationToken);
          if (userNotificationSettings == null)
          {
             var newUserNotificationSettings = new UserNotificationSetting(userId, enableTransferNotifications, emailNotifications);
@@ -54,12 +55,12 @@ namespace Crypter.Core.Services.DataAccess
             userNotificationSettings.EmailNotifications = emailNotifications;
          }
 
-         await Context.SaveChangesAsync();
+         await Context.SaveChangesAsync(cancellationToken);
       }
 
-      public async Task<IUserNotificationSetting> ReadAsync(Guid userId)
+      public async Task<IUserNotificationSetting> ReadAsync(Guid userId, CancellationToken cancellationToken)
       {
-         return await Context.UserNotificationSetting.FindAsync(userId);
+         return await Context.UserNotificationSetting.FindAsync(new object[] { userId }, cancellationToken);
       }
    }
 }

--- a/Crypter.Core/Services/DataAccess/UserProfileService.cs
+++ b/Crypter.Core/Services/DataAccess/UserProfileService.cs
@@ -27,6 +27,7 @@
 using Crypter.Core.Interfaces;
 using Crypter.Core.Models;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Services.DataAccess
@@ -40,14 +41,14 @@ namespace Crypter.Core.Services.DataAccess
          Context = context;
       }
 
-      public async Task<IUserProfile> ReadAsync(Guid id)
+      public async Task<IUserProfile> ReadAsync(Guid id, CancellationToken cancellationToken)
       {
-         return await Context.UserProfile.FindAsync(id);
+         return await Context.UserProfile.FindAsync(new object[] { id }, cancellationToken);
       }
 
-      public async Task<bool> UpsertAsync(Guid id, string alias, string about)
+      public async Task<bool> UpsertAsync(Guid id, string alias, string about, CancellationToken cancellationToken)
       {
-         var userProfile = await ReadAsync(id);
+         var userProfile = await ReadAsync(id, cancellationToken);
          if (userProfile == null)
          {
             var newProfile = new UserProfile(id, alias, about, null);
@@ -59,7 +60,7 @@ namespace Crypter.Core.Services.DataAccess
             userProfile.About = about;
          }
 
-         await Context.SaveChangesAsync();
+         await Context.SaveChangesAsync(cancellationToken);
          return true;
       }
    }

--- a/Crypter.Core/Services/DataAccess/UserSearchService.cs
+++ b/Crypter.Core/Services/DataAccess/UserSearchService.cs
@@ -31,6 +31,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Services.DataAccess
@@ -44,7 +45,7 @@ namespace Crypter.Core.Services.DataAccess
          Context = context;
       }
 
-      public async Task<(int total, IEnumerable<UserSearchResultDTO> users)> SearchByUsernameAsync(Guid searchParty, string query, int startingIndex, int count)
+      public async Task<(int total, IEnumerable<UserSearchResultDTO> users)> SearchByUsernameAsync(Guid searchParty, string query, int startingIndex, int count, CancellationToken cancellationToken)
       {
          var lowerUsername = query.ToLower();
 
@@ -52,7 +53,7 @@ namespace Crypter.Core.Services.DataAccess
             .Where(x => x.Username.ToLower().StartsWith(lowerUsername))
             .Where(x => x.PrivacySetting.Visibility == UserVisibilityLevel.Everyone
                || (x.PrivacySetting.Visibility == UserVisibilityLevel.Authenticated && searchParty != Guid.Empty))
-            .CountAsync();
+            .CountAsync(cancellationToken);
 
          var users = await Context.User
             .Where(x => x.Username.ToLower().StartsWith(lowerUsername))
@@ -67,12 +68,12 @@ namespace Crypter.Core.Services.DataAccess
                   x.Username,
                   x.Profile.Alias
                ))
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
 
          return (totalMatches, users);
       }
 
-      public async Task<(int total, IEnumerable<UserSearchResultDTO> users)> SearchByAliasAsync(Guid searchParty, string query, int startingIndex, int count)
+      public async Task<(int total, IEnumerable<UserSearchResultDTO> users)> SearchByAliasAsync(Guid searchParty, string query, int startingIndex, int count, CancellationToken cancellationToken)
       {
          var lowerAlias = query.ToLower();
 
@@ -80,7 +81,7 @@ namespace Crypter.Core.Services.DataAccess
             .Where(x => x.Alias.ToLower().StartsWith(lowerAlias))
             .Where(x => x.User.PrivacySetting.Visibility == UserVisibilityLevel.Everyone
                || (x.User.PrivacySetting.Visibility == UserVisibilityLevel.Authenticated && searchParty != Guid.Empty))
-            .CountAsync();
+            .CountAsync(cancellationToken);
 
          var users = await Context.UserProfile
             .Where(x => x.Alias.ToLower().StartsWith(lowerAlias))
@@ -95,7 +96,7 @@ namespace Crypter.Core.Services.DataAccess
                   x.User.Username,
                   x.Alias
                ))
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
 
          return (totalMatches, users);
       }

--- a/Crypter.Core/Services/DataAccess/UserX25519KeyPairService.cs
+++ b/Crypter.Core/Services/DataAccess/UserX25519KeyPairService.cs
@@ -29,6 +29,7 @@ using Crypter.Core.Models;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Services.DataAccess
@@ -42,24 +43,24 @@ namespace Crypter.Core.Services.DataAccess
          Context = context;
       }
 
-      public async Task<IUserPublicKeyPair> GetUserPublicKeyPairAsync(Guid userId)
+      public async Task<IUserPublicKeyPair> GetUserPublicKeyPairAsync(Guid userId, CancellationToken cancellationToken)
       {
          return await Context.UserX25519KeyPair
              .Where(x => x.Owner == userId)
-             .FirstOrDefaultAsync();
+             .FirstOrDefaultAsync(cancellationToken);
       }
 
-      public async Task<string> GetUserPublicKeyAsync(Guid userId)
+      public async Task<string> GetUserPublicKeyAsync(Guid userId, CancellationToken cancellationToken)
       {
          var keyPair = await Context.UserX25519KeyPair
              .Where(x => x.Owner == userId)
-             .FirstOrDefaultAsync();
+             .FirstOrDefaultAsync(cancellationToken);
          return keyPair?.PublicKey;
       }
 
-      public async Task<bool> InsertUserPublicKeyPairAsync(Guid userId, string privateKey, string publicKey, string clientIV)
+      public async Task<bool> InsertUserPublicKeyPairAsync(Guid userId, string privateKey, string publicKey, string clientIV, CancellationToken cancellationToken)
       {
-         if (await GetUserPublicKeyPairAsync(userId) != default(UserX25519KeyPair))
+         if (await GetUserPublicKeyPairAsync(userId, cancellationToken) != default(UserX25519KeyPair))
          {
             return false;
          }
@@ -73,7 +74,7 @@ namespace Crypter.Core.Services.DataAccess
              DateTime.UtcNow);
 
          Context.UserX25519KeyPair.Add(key);
-         await Context.SaveChangesAsync();
+         await Context.SaveChangesAsync(cancellationToken);
          return true;
       }
    }

--- a/Crypter.Core/Services/TransferItemStorageService.cs
+++ b/Crypter.Core/Services/TransferItemStorageService.cs
@@ -28,6 +28,7 @@ using Crypter.Contracts.Enum;
 using Crypter.Core.Interfaces;
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Core.Services
@@ -43,14 +44,14 @@ namespace Crypter.Core.Services
          ItemType = itemType;
       }
 
-      public async Task<bool> SaveAsync(Guid id, byte[] data)
+      public async Task<bool> SaveAsync(Guid id, byte[] data, CancellationToken cancellationToken)
       {
          var newDirectory = Path.Join(StoragePath, id.ToString().ToLower());
          Directory.CreateDirectory(newDirectory);
          var newFile = Path.Join(newDirectory, ItemType.ToString());
          try
          {
-            await File.WriteAllBytesAsync(newFile, data);
+            await File.WriteAllBytesAsync(newFile, data, cancellationToken);
          }
          catch (Exception)
          {
@@ -59,11 +60,11 @@ namespace Crypter.Core.Services
          return true;
       }
 
-      public async Task<byte[]> ReadAsync(Guid id)
+      public async Task<byte[]> ReadAsync(Guid id, CancellationToken cancellationToken)
       {
          var itemDirectory = Path.Join(StoragePath, id.ToString().ToLower());
          var file = Path.Join(itemDirectory, ItemType.ToString());
-         return await File.ReadAllBytesAsync(file);
+         return await File.ReadAllBytesAsync(file, cancellationToken);
       }
 
       public bool Delete(Guid id)

--- a/Crypter.CryptoLib/Crypto/SHA.cs
+++ b/Crypter.CryptoLib/Crypto/SHA.cs
@@ -59,25 +59,5 @@ namespace Crypter.CryptoLib.Crypto
          Digestor.Reset();
          return hash;
       }
-
-      public bool CompareNewInputAgainstKnownDigest(byte[] newInput, byte[] knownDigest)
-      {
-         BlockUpdate(newInput);
-         var newDigest = GetDigest();
-
-         if (newDigest.Length != knownDigest.Length)
-         {
-            return false;
-         }
-
-         for (int i = 0; i < knownDigest.Length; i++)
-         {
-            if (!knownDigest[i].Equals(newDigest[i]))
-            {
-               return false;
-            }
-         }
-         return true;
-      }
    }
 }

--- a/Crypter.CryptoLib/Services/SimpleEncryptionService.cs
+++ b/Crypter.CryptoLib/Services/SimpleEncryptionService.cs
@@ -25,9 +25,10 @@
  */
 
 using Crypter.CryptoLib.Crypto;
+using System;
 using System.Text;
 
-namespace Crypter.Web.Services
+namespace Crypter.CryptoLib.Services
 {
    public interface ISimpleEncryptionService
    {

--- a/Crypter.CryptoLib/Services/SimpleHashService.cs
+++ b/Crypter.CryptoLib/Services/SimpleHashService.cs
@@ -24,27 +24,52 @@
  * Contact the current copyright holder to discuss commerical license options.
  */
 
-using Crypter.Contracts.Enum;
-using Crypter.Core.Models;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
+using Crypter.CryptoLib.Crypto;
+using Crypter.CryptoLib.Enums;
 
-namespace Crypter.Core.Interfaces
+namespace Crypter.CryptoLib.Services
 {
-   public interface IUserService
+   public interface ISimpleHashService
    {
-      Task<Guid> InsertAsync(string username, string password, string email, CancellationToken cancellationToken);
-      Task<IUser> ReadAsync(Guid id, CancellationToken cancellationToken);
-      Task<IUser> ReadAsync(string username, CancellationToken cancellationToken);
-      Task<UpdateContactInfoResult> UpdateContactInfoAsync(Guid id, string email, string currentPassword, CancellationToken cancellationToken);
-      Task UpdateEmailAddressVerification(Guid id, bool isVerified, CancellationToken cancellationToken);
-      Task DeleteAsync(Guid id, CancellationToken cancellationToken);
+      byte[] DigestSha256(byte[] data);
+      byte[] DigestSha512(byte[] data);
+      bool CompareDigests(byte[] expected, byte[] actual);
+   }
 
-      Task<User> AuthenticateAsync(string username, string password, CancellationToken cancellationToken);
-      Task UpdateLastLoginTime(Guid id, DateTime dateTime, CancellationToken cancellationToken);
+   public class SimpleHashService : ISimpleHashService
+   {
+      public byte[] DigestSha256(byte[] data)
+      {
+         return DigestBase(SHAFunction.SHA256, data);
+      }
 
-      Task<bool> IsUsernameAvailableAsync(string username, CancellationToken cancellationToken);
-      Task<bool> IsEmailAddressAvailableAsync(string email, CancellationToken cancellationToken);
+      public byte[] DigestSha512(byte[] data)
+      {
+         return DigestBase(SHAFunction.SHA512, data);
+      }
+
+      public bool CompareDigests(byte[] expected, byte[] actual)
+      {
+         if (expected.Length != actual.Length)
+         {
+            return false;
+         }
+
+         for (int i = 0; i < actual.Length; i++)
+         {
+            if (!actual[i].Equals(expected[i]))
+            {
+               return false;
+            }
+         }
+         return true;
+      }
+
+      private byte[] DigestBase(SHAFunction function, byte[] data)
+      {
+         var digestor = new SHA(function);
+         digestor.BlockUpdate(data);
+         return digestor.GetDigest();
+      }
    }
 }

--- a/Crypter.Test/API_Tests/EmailService_Tests.cs
+++ b/Crypter.Test/API_Tests/EmailService_Tests.cs
@@ -33,6 +33,7 @@ using NUnit.Framework;
 using Org.BouncyCastle.Crypto;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Crypter.Test.API_Tests
@@ -70,12 +71,12 @@ namespace Crypter.Test.API_Tests
          var mockUserService = new Mock<IUserService>();
          mockUserService
             .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
-            .ReturnsAsync((Guid userId) => null);
+            .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => null);
 
          var mockUserEmailVerificationService = new Mock<IUserEmailVerificationService>();
          mockUserEmailVerificationService
             .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
-            .ReturnsAsync((Guid userId) => null);
+            .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
          var mockMessageTransferService = new Mock<IBaseTransferService<MessageTransfer>>();
@@ -101,12 +102,12 @@ namespace Crypter.Test.API_Tests
          var mockUserService = new Mock<IUserService>();
          mockUserService
             .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
-            .ReturnsAsync((Guid userId) => user);
+            .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => user);
 
          var mockUserEmailVerificationService = new Mock<IUserEmailVerificationService>();
          mockUserEmailVerificationService
             .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
-            .ReturnsAsync((Guid userId) => null);
+            .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
          var mockMessageTransferService = new Mock<IBaseTransferService<MessageTransfer>>();
@@ -132,12 +133,12 @@ namespace Crypter.Test.API_Tests
          var mockUserService = new Mock<IUserService>();
          mockUserService
             .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
-            .ReturnsAsync((Guid userId) => user);
+            .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => user);
 
          var mockUserEmailVerificationService = new Mock<IUserEmailVerificationService>();
          mockUserEmailVerificationService
             .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
-            .ReturnsAsync((Guid userId) => null);
+            .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
          var mockMessageTransferService = new Mock<IBaseTransferService<MessageTransfer>>();
@@ -163,12 +164,12 @@ namespace Crypter.Test.API_Tests
          var mockUserService = new Mock<IUserService>();
          mockUserService
             .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
-            .ReturnsAsync((Guid userId) => user);
+            .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => user);
 
          var mockUserEmailVerificationService = new Mock<IUserEmailVerificationService>();
          mockUserEmailVerificationService
             .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
-            .ReturnsAsync((Guid userId) => null);
+            .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
          var mockMessageTransferService = new Mock<IBaseTransferService<MessageTransfer>>();
@@ -194,14 +195,14 @@ namespace Crypter.Test.API_Tests
          var mockUserService = new Mock<IUserService>();
          mockUserService
             .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
-            .ReturnsAsync((Guid userId) => user);
+            .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => user);
 
          var userVerification = new UserEmailVerification(user.Id, Guid.NewGuid(), default, DateTime.UtcNow);
 
          var mockUserEmailVerificationService = new Mock<IUserEmailVerificationService>();
          mockUserEmailVerificationService
             .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
-            .ReturnsAsync((Guid userId) => userVerification);
+            .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => userVerification);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
          var mockMessageTransferService = new Mock<IBaseTransferService<MessageTransfer>>();
@@ -227,12 +228,12 @@ namespace Crypter.Test.API_Tests
          var mockUserService = new Mock<IUserService>();
          mockUserService
             .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
-            .ReturnsAsync((Guid userId) => user);
+            .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => user);
 
          var mockUserEmailVerificationService = new Mock<IUserEmailVerificationService>();
          mockUserEmailVerificationService
             .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
-            .ReturnsAsync((Guid userId) => null);
+            .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
          var mockMessageTransferService = new Mock<IBaseTransferService<MessageTransfer>>();

--- a/Crypter.Test/API_Tests/EmailService_Tests.cs
+++ b/Crypter.Test/API_Tests/EmailService_Tests.cs
@@ -69,12 +69,12 @@ namespace Crypter.Test.API_Tests
       {
          var mockUserService = new Mock<IUserService>();
          mockUserService
-            .Setup(x => x.ReadAsync(It.IsAny<Guid>()))
+            .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
             .ReturnsAsync((Guid userId) => null);
 
          var mockUserEmailVerificationService = new Mock<IUserEmailVerificationService>();
          mockUserEmailVerificationService
-            .Setup(x => x.ReadAsync(It.IsAny<Guid>()))
+            .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
             .ReturnsAsync((Guid userId) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
@@ -90,7 +90,7 @@ namespace Crypter.Test.API_Tests
 
          emailService.Verify(x => x.SendEmailVerificationAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<AsymmetricKeyParameter>()), Times.Never);
          emailService.Verify(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-         mockUserEmailVerificationService.Verify(x => x.InsertAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<byte[]>()), Times.Never);
+         mockUserEmailVerificationService.Verify(x => x.InsertAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<byte[]>(), default), Times.Never);
       }
 
       [Test]
@@ -100,12 +100,12 @@ namespace Crypter.Test.API_Tests
 
          var mockUserService = new Mock<IUserService>();
          mockUserService
-            .Setup(x => x.ReadAsync(It.IsAny<Guid>()))
+            .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
             .ReturnsAsync((Guid userId) => user);
 
          var mockUserEmailVerificationService = new Mock<IUserEmailVerificationService>();
          mockUserEmailVerificationService
-            .Setup(x => x.ReadAsync(It.IsAny<Guid>()))
+            .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
             .ReturnsAsync((Guid userId) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
@@ -121,7 +121,7 @@ namespace Crypter.Test.API_Tests
 
          emailService.Verify(x => x.SendEmailVerificationAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<AsymmetricKeyParameter>()), Times.Never);
          emailService.Verify(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-         mockUserEmailVerificationService.Verify(x => x.InsertAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<byte[]>()), Times.Never);
+         mockUserEmailVerificationService.Verify(x => x.InsertAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<byte[]>(), default), Times.Never);
       }
 
       [Test]
@@ -131,12 +131,12 @@ namespace Crypter.Test.API_Tests
 
          var mockUserService = new Mock<IUserService>();
          mockUserService
-            .Setup(x => x.ReadAsync(It.IsAny<Guid>()))
+            .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
             .ReturnsAsync((Guid userId) => user);
 
          var mockUserEmailVerificationService = new Mock<IUserEmailVerificationService>();
          mockUserEmailVerificationService
-            .Setup(x => x.ReadAsync(It.IsAny<Guid>()))
+            .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
             .ReturnsAsync((Guid userId) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
@@ -152,7 +152,7 @@ namespace Crypter.Test.API_Tests
 
          emailService.Verify(x => x.SendEmailVerificationAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<AsymmetricKeyParameter>()), Times.Never);
          emailService.Verify(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-         mockUserEmailVerificationService.Verify(x => x.InsertAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<byte[]>()), Times.Never);
+         mockUserEmailVerificationService.Verify(x => x.InsertAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<byte[]>(), default), Times.Never);
       }
 
       [Test]
@@ -162,12 +162,12 @@ namespace Crypter.Test.API_Tests
 
          var mockUserService = new Mock<IUserService>();
          mockUserService
-            .Setup(x => x.ReadAsync(It.IsAny<Guid>()))
+            .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
             .ReturnsAsync((Guid userId) => user);
 
          var mockUserEmailVerificationService = new Mock<IUserEmailVerificationService>();
          mockUserEmailVerificationService
-            .Setup(x => x.ReadAsync(It.IsAny<Guid>()))
+            .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
             .ReturnsAsync((Guid userId) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
@@ -183,7 +183,7 @@ namespace Crypter.Test.API_Tests
 
          emailService.Verify(x => x.SendEmailVerificationAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<AsymmetricKeyParameter>()), Times.Never);
          emailService.Verify(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-         mockUserEmailVerificationService.Verify(x => x.InsertAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<byte[]>()), Times.Never);
+         mockUserEmailVerificationService.Verify(x => x.InsertAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<byte[]>(), default), Times.Never);
       }
 
       [Test]
@@ -193,14 +193,14 @@ namespace Crypter.Test.API_Tests
 
          var mockUserService = new Mock<IUserService>();
          mockUserService
-            .Setup(x => x.ReadAsync(It.IsAny<Guid>()))
+            .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
             .ReturnsAsync((Guid userId) => user);
 
          var userVerification = new UserEmailVerification(user.Id, Guid.NewGuid(), default, DateTime.UtcNow);
 
          var mockUserEmailVerificationService = new Mock<IUserEmailVerificationService>();
          mockUserEmailVerificationService
-            .Setup(x => x.ReadAsync(It.IsAny<Guid>()))
+            .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
             .ReturnsAsync((Guid userId) => userVerification);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
@@ -216,7 +216,7 @@ namespace Crypter.Test.API_Tests
 
          emailService.Verify(x => x.SendEmailVerificationAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<AsymmetricKeyParameter>()), Times.Never);
          emailService.Verify(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-         mockUserEmailVerificationService.Verify(x => x.InsertAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<byte[]>()), Times.Never);
+         mockUserEmailVerificationService.Verify(x => x.InsertAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<byte[]>(), default), Times.Never);
       }
 
       [Test]
@@ -226,12 +226,12 @@ namespace Crypter.Test.API_Tests
 
          var mockUserService = new Mock<IUserService>();
          mockUserService
-            .Setup(x => x.ReadAsync(It.IsAny<Guid>()))
+            .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
             .ReturnsAsync((Guid userId) => user);
 
          var mockUserEmailVerificationService = new Mock<IUserEmailVerificationService>();
          mockUserEmailVerificationService
-            .Setup(x => x.ReadAsync(It.IsAny<Guid>()))
+            .Setup(x => x.ReadAsync(It.IsAny<Guid>(), default))
             .ReturnsAsync((Guid userId) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
@@ -247,7 +247,7 @@ namespace Crypter.Test.API_Tests
 
          emailService.Verify(x => x.SendEmailVerificationAsync(user.Email, It.IsAny<Guid>(), It.IsAny<AsymmetricKeyParameter>()), Times.Once);
          emailService.Verify(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), user.Email), Times.Once);
-         mockUserEmailVerificationService.Verify(x => x.InsertAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<byte[]>()), Times.Never);
+         mockUserEmailVerificationService.Verify(x => x.InsertAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<byte[]>(), default), Times.Never);
       }
 
       [Test]

--- a/Crypter.Web/Program.cs
+++ b/Crypter.Web/Program.cs
@@ -34,6 +34,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using Crypter.Web.Services.API;
+using Crypter.CryptoLib.Services;
 
 namespace Crypter.Web
 {

--- a/Crypter.Web/Services/AuthenticationService.cs
+++ b/Crypter.Web/Services/AuthenticationService.cs
@@ -27,6 +27,7 @@
 using Crypter.Contracts.Enum;
 using Crypter.Contracts.Requests;
 using Crypter.Contracts.Responses;
+using Crypter.CryptoLib.Services;
 using Crypter.Web.Models.LocalStorage;
 using Crypter.Web.Services.API;
 using System;

--- a/Crypter.Web/Services/UserKeysService.cs
+++ b/Crypter.Web/Services/UserKeysService.cs
@@ -51,13 +51,6 @@ namespace Crypter.Web.Services
 
    public class UserKeysService : IUserKeysService
    {
-      private readonly ISimpleEncryptionService _simpleEncryptionService;
-
-      public UserKeysService(ISimpleEncryptionService simpleEncryptionService)
-      {
-         _simpleEncryptionService = simpleEncryptionService;
-      }
-
       public (string privateKey, string publicKey) NewX25519KeyPair()
       {
          var keyPair = CryptoLib.Crypto.ECDH.GenerateKeys();


### PR DESCRIPTION
I began writing this pull request to implement several, common services that should make performing basic cryptographic functions more easy.  These are located in Crypter.CryptoLib/Services:

- SimpleEncryptionService
- SimpleHashService
- SimpleSignatureService

Then I got distracted and began implementing CancellationTokens through the solution.

Finally, I discovered and resolved a bug that was preventing users from saving a new email address.

Resolve #184 
Resolve #185 