### PR TITLE
LocalStorageService improvements and unit tests

### DIFF
--- a/Crypter.Test/Crypter.Test.csproj
+++ b/Crypter.Test/Crypter.Test.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\Crypter.API\Crypter.API.csproj" />
     <ProjectReference Include="..\Crypter.Core\Crypter.Core.csproj" />
     <ProjectReference Include="..\Crypter.CryptoLib\Crypter.CryptoLib.csproj" />
+    <ProjectReference Include="..\Crypter.Web\Crypter.Web.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Crypter.Test/Web_Tests/LocalStorageService_Tests.cs
+++ b/Crypter.Test/Web_Tests/LocalStorageService_Tests.cs
@@ -1,0 +1,138 @@
+﻿using Crypter.Web.Models.LocalStorage;
+using Crypter.Web.Services;
+using Microsoft.JSInterop;
+using Moq;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+
+namespace Crypter.Test.Web_Tests
+{
+   [TestFixture]
+   public class LocalStorageService_Tests
+   {
+      [SetUp]
+      public void Setup()
+      {
+      }
+
+      [Test]
+      public async Task Service_Properly_Identifies_As_Initialized()
+      {
+      var jsRuntime = new Mock<IJSRuntime>();
+      jsRuntime
+         .Setup(x => x.InvokeAsync<string>(It.IsAny<string>(), new object[] { It.IsAny<string>() }))
+         .ReturnsAsync((string command, string itemType) => default);
+
+         var sut = new LocalStorageService(jsRuntime.Object);
+
+         Assert.IsFalse(sut.IsInitialized);
+         await sut.InitializeAsync();
+         Assert.IsTrue(sut.IsInitialized);
+      }
+
+      [Test]
+      public async Task Storage_Is_Empty_Upon_Initialization_Without_Existing_Data()
+      {
+         var jsRuntime = new Mock<IJSRuntime>();
+         jsRuntime
+            .Setup(x => x.InvokeAsync<string>(It.IsAny<string>(), new object[] { It.IsAny<string>() }))
+            .ReturnsAsync((string command, string itemType) => default);
+
+         var sut = new LocalStorageService(jsRuntime.Object);
+         await sut.InitializeAsync();
+
+         foreach (StoredObjectType item in Enum.GetValues(typeof(StoredObjectType)))
+         {
+            Assert.IsFalse(sut.HasItem(item));
+         }
+      }
+
+      [TestCase(LocalStorageService.SessionStorageLiteral, StorageLocation.SessionStorage)]
+      [TestCase(LocalStorageService.LocalStorageLiteral, StorageLocation.LocalStorage)]
+      public async Task Service_Initializes_Values_From_Browser_Storage(string storageLiteral, StorageLocation storageLocation)
+      {
+         var storedUserSession = new UserSession(Guid.NewGuid(), "foo", "1234", "5678");
+         var storedAuthToken = "authToken";
+         var plaintextX25519PrivateKey = "plaintextX25519";
+         var plaintextEd25519PrivateKey = "plaintextEd25519";
+         var encryptedX25519PrivateKey = "encryptedX25519";
+         var encryptedEd25519PrivateKey = "encryptedEd25519";
+
+         var jsRuntime = new Mock<IJSRuntime>();
+
+         // UserSession
+         jsRuntime
+            .Setup(x => x.InvokeAsync<string>(
+               It.Is<string>(x => x == $"{storageLiteral}.getItem"),
+               It.Is<object[]>(x => x[0].ToString() == StoredObjectType.UserSession.ToString())))
+            .ReturnsAsync((string command, object[] args) => JsonConvert.SerializeObject(storedUserSession));
+
+         // AuthToken
+         jsRuntime
+            .Setup(x => x.InvokeAsync<string>(
+               It.Is<string>(x => x == $"{storageLiteral}.getItem"),
+               It.Is<object[]>(x => x[0].ToString() == StoredObjectType.AuthToken.ToString())))
+            .ReturnsAsync((string command, object[] args) => JsonConvert.SerializeObject(storedAuthToken));
+
+         // PlaintextX25519PrivateKey
+         jsRuntime
+            .Setup(x => x.InvokeAsync<string>(
+               It.Is<string>(x => x == $"{storageLiteral}.getItem"),
+               It.Is<object[]>(x => x[0].ToString() == StoredObjectType.PlaintextX25519PrivateKey.ToString())))
+            .ReturnsAsync((string command, object[] args) => JsonConvert.SerializeObject(plaintextX25519PrivateKey));
+
+         // PlaintextEd25519PrivateKey
+         jsRuntime
+            .Setup(x => x.InvokeAsync<string>(
+               It.Is<string>(x => x == $"{storageLiteral}.getItem"),
+               It.Is<object[]>(x => x[0].ToString() == StoredObjectType.PlaintextEd25519PrivateKey.ToString())))
+            .ReturnsAsync((string command, object[] args) => JsonConvert.SerializeObject(plaintextEd25519PrivateKey));
+
+         // EncryptedX25519PrivateKey
+         jsRuntime
+            .Setup(x => x.InvokeAsync<string>(
+               It.Is<string>(x => x == $"{storageLiteral}.getItem"),
+               It.Is<object[]>(x => x[0].ToString() == StoredObjectType.EncryptedX25519PrivateKey.ToString())))
+            .ReturnsAsync((string command, object[] args) => JsonConvert.SerializeObject(encryptedX25519PrivateKey));
+
+         // EncryptedEd25519PrivateKey
+         jsRuntime
+            .Setup(x => x.InvokeAsync<string>(
+               It.Is<string>(x => x == $"{storageLiteral}.getItem"),
+               It.Is<object[]>(x => x[0].ToString() == StoredObjectType.EncryptedEd25519PrivateKey.ToString())))
+            .ReturnsAsync((string command, object[] args) => JsonConvert.SerializeObject(encryptedEd25519PrivateKey));
+
+         var sut = new LocalStorageService(jsRuntime.Object);
+         await sut.InitializeAsync();
+
+         foreach (StoredObjectType item in Enum.GetValues(typeof(StoredObjectType)))
+         {
+            Assert.IsTrue(sut.HasItem(item));
+            Assert.AreEqual(storageLocation, sut.GetItemLocation(item));
+         }
+
+         var fetchedUserSession = await sut.GetItemAsync<UserSession>(StoredObjectType.UserSession);
+         Assert.AreEqual(storedUserSession.UserId, fetchedUserSession.UserId);
+         Assert.AreEqual(storedUserSession.Username, fetchedUserSession.Username);
+         Assert.AreEqual(storedUserSession.EncryptedAuthToken, fetchedUserSession.EncryptedAuthToken);
+         Assert.AreEqual(storedUserSession.AuthTokenIV, fetchedUserSession.AuthTokenIV);
+
+         var fetchedAuthToken = await sut.GetItemAsync<string>(StoredObjectType.AuthToken);
+         Assert.AreEqual(storedAuthToken, fetchedAuthToken);
+
+         var fetchedPlaintextX25519PrivateKey = await sut.GetItemAsync<string>(StoredObjectType.PlaintextX25519PrivateKey);
+         Assert.AreEqual(plaintextX25519PrivateKey, fetchedPlaintextX25519PrivateKey);
+
+         var fetchedPlaintextEd25519PrivateKey = await sut.GetItemAsync<string>(StoredObjectType.PlaintextEd25519PrivateKey);
+         Assert.AreEqual(plaintextEd25519PrivateKey, fetchedPlaintextEd25519PrivateKey);
+
+         var fetchedEncryptedX25519PrivateKey = await sut.GetItemAsync<string>(StoredObjectType.EncryptedX25519PrivateKey);
+         Assert.AreEqual(encryptedX25519PrivateKey, fetchedEncryptedX25519PrivateKey);
+
+         var fetchedEncryptedEd25519PrivateKey = await sut.GetItemAsync<string>(StoredObjectType.EncryptedEd25519PrivateKey);
+         Assert.AreEqual(encryptedEd25519PrivateKey, fetchedEncryptedEd25519PrivateKey);
+      }
+   }
+}

--- a/Crypter.Web/Services/LocalStorageService.cs
+++ b/Crypter.Web/Services/LocalStorageService.cs
@@ -25,9 +25,9 @@
  */
 
 using Microsoft.JSInterop;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Crypter.Web.Services
@@ -55,6 +55,7 @@ namespace Crypter.Web.Services
       Task InitializeAsync();
       Task<T> GetItemAsync<T>(StoredObjectType itemType);
       bool HasItem(StoredObjectType itemType);
+      StorageLocation GetItemLocation(StoredObjectType itemType);
       Task SetItemAsync<T>(StoredObjectType itemType, T value, StorageLocation location);
       Task RemoveItemAsync(StoredObjectType itemType);
       Task DisposeAsync();
@@ -62,21 +63,21 @@ namespace Crypter.Web.Services
 
    public class LocalStorageService : ILocalStorageService
    {
-      private const string SessionStorageLiteral = "sessionStorage";
-      private const string LocalStorageLiteral = "localStorage";
+      public const string SessionStorageLiteral = "sessionStorage";
+      public const string LocalStorageLiteral = "localStorage";
 
-      private readonly IJSRuntime JSRuntime;
+      private readonly IJSRuntime _jsRuntime;
 
-      private readonly Dictionary<string, object> InMemoryStorage;
-      private readonly Dictionary<string, StorageLocation> ObjectLocations;
+      private readonly Dictionary<string, object> _inMemoryStorage;
+      private readonly Dictionary<string, StorageLocation> _objectLocations;
 
       public bool IsInitialized { get; private set; } = false;
 
       public LocalStorageService(IJSRuntime jSRuntime)
       {
-         JSRuntime = jSRuntime;
-         InMemoryStorage = new Dictionary<string, object>();
-         ObjectLocations = new Dictionary<string, StorageLocation>();
+         _jsRuntime = jSRuntime;
+         _inMemoryStorage = new Dictionary<string, object>();
+         _objectLocations = new Dictionary<string, StorageLocation>();
       }
 
       public async Task InitializeAsync()
@@ -94,84 +95,92 @@ namespace Crypter.Web.Services
 
       private async Task InitializeItemFromLocalStorage(StoredObjectType itemType)
       {
-         var value = await JSRuntime.InvokeAsync<string>($"{LocalStorageLiteral}.getItem", itemType.ToString());
+         var value = await _jsRuntime.InvokeAsync<string>($"{LocalStorageLiteral}.getItem", new object[] { itemType.ToString() });
          if (!string.IsNullOrEmpty(value))
          {
-            ObjectLocations.Add(itemType.ToString(), StorageLocation.LocalStorage);
+            _objectLocations.Add(itemType.ToString(), StorageLocation.LocalStorage);
          }
       }
 
       private async Task InitializeItemFromSessionStorage(StoredObjectType itemType)
       {
-         var value = await JSRuntime.InvokeAsync<string>($"{SessionStorageLiteral}.getItem", itemType.ToString());
+         var value = await _jsRuntime.InvokeAsync<string>($"{SessionStorageLiteral}.getItem", new object[] { itemType.ToString() });
          if (!string.IsNullOrEmpty(value))
          {
-            ObjectLocations.Add(itemType.ToString(), StorageLocation.SessionStorage);
+            _objectLocations.Add(itemType.ToString(), StorageLocation.SessionStorage);
          }
       }
 
       public async Task<T> GetItemAsync<T>(StoredObjectType itemType)
       {
-         if (ObjectLocations.TryGetValue(itemType.ToString(), out var location))
+         if (_objectLocations.TryGetValue(itemType.ToString(), out var location))
          {
             string storedJson;
             switch (location)
             {
                case StorageLocation.InMemory:
-                  return (T)InMemoryStorage[itemType.ToString()];
+                  return (T)_inMemoryStorage[itemType.ToString()];
                case StorageLocation.SessionStorage:
-                  storedJson = await JSRuntime.InvokeAsync<string>($"{SessionStorageLiteral}.getItem", itemType.ToString());
+                  storedJson = await _jsRuntime.InvokeAsync<string>($"{SessionStorageLiteral}.getItem", new object[] { itemType.ToString() });
                   break;
                case StorageLocation.LocalStorage:
-                  storedJson = await JSRuntime.InvokeAsync<string>($"{LocalStorageLiteral}.getItem", itemType.ToString());
+                  storedJson = await _jsRuntime.InvokeAsync<string>($"{LocalStorageLiteral}.getItem", new object[] { itemType.ToString() });
                   break;
                default:
                   throw new NotImplementedException();
             }
-            return JsonSerializer.Deserialize<T>(storedJson);
+            return JsonConvert.DeserializeObject<T>(storedJson);
          }
          return default;
       }
 
       public bool HasItem(StoredObjectType itemType)
       {
-         return ObjectLocations.ContainsKey(itemType.ToString());
+         return _objectLocations.ContainsKey(itemType.ToString());
+      }
+
+      public StorageLocation GetItemLocation(StoredObjectType itemType)
+      {
+         return _objectLocations[itemType.ToString()];
       }
 
       public async Task SetItemAsync<T>(StoredObjectType itemType, T value, StorageLocation location)
       {
-         ObjectLocations.TryAdd(itemType.ToString(), location);
+         await RemoveItemAsync(itemType);
+
          switch (location)
          {
             case StorageLocation.InMemory:
-               InMemoryStorage.Add(itemType.ToString(), value);
+               _inMemoryStorage.Add(itemType.ToString(), value);
                break;
             case StorageLocation.SessionStorage:
-               await JSRuntime.InvokeAsync<string>($"{SessionStorageLiteral}.setItem", itemType.ToString(), JsonSerializer.Serialize(value));
+               await _jsRuntime.InvokeAsync<string>($"{SessionStorageLiteral}.setItem", new object[] { itemType.ToString(), JsonConvert.SerializeObject(value) });
                break;
             case StorageLocation.LocalStorage:
-               await JSRuntime.InvokeAsync<string>($"{LocalStorageLiteral}.setItem", itemType.ToString(), JsonSerializer.Serialize(value));
+               await _jsRuntime.InvokeAsync<string>($"{LocalStorageLiteral}.setItem", new object[] { itemType.ToString(), JsonConvert.SerializeObject(value) });
                break;
             default:
                throw new NotImplementedException();
          }
+
+         _objectLocations.Add(itemType.ToString(), location);
       }
 
       public async Task RemoveItemAsync(StoredObjectType itemType)
       {
-         if (ObjectLocations.TryGetValue(itemType.ToString(), out var location))
+         if (_objectLocations.TryGetValue(itemType.ToString(), out var location))
          {
-            ObjectLocations.Remove(itemType.ToString());
+            _objectLocations.Remove(itemType.ToString());
             switch (location)
             {
                case StorageLocation.InMemory:
-                  InMemoryStorage.Remove(itemType.ToString());
+                  _inMemoryStorage.Remove(itemType.ToString());
                   break;
                case StorageLocation.SessionStorage:
-                  await JSRuntime.InvokeAsync<string>($"{SessionStorageLiteral}.removeItem", itemType.ToString());
+                  await _jsRuntime.InvokeAsync<string>($"{SessionStorageLiteral}.removeItem", itemType.ToString());
                   break;
                case StorageLocation.LocalStorage:
-                  await JSRuntime.InvokeAsync<string>($"{LocalStorageLiteral}.removeItem", itemType.ToString());
+                  await _jsRuntime.InvokeAsync<string>($"{LocalStorageLiteral}.removeItem", itemType.ToString());
                   break;
                default:
                   throw new NotImplementedException();


### PR DESCRIPTION
`SetItemAsync` was previously encountering an error if you tried to store something in memory, but a previous version of that thing already existed in memory.  Specifically, the method was trying to add a duplicate key to the `_inMemoryStorage` dictionary.  This bug does not impact the current release; it's something I caught while working on #44 .

What I would have expected is for whatever was currently stored to be overwritten.

This patch modifies `SetItemAsync` to immediately invoke `RemoveItemAsync`.  Along with resolving the error already mentioned, this should also prevent items which are already stored from becoming untracked when `SetItemAsync` is called to store a new version of something in a different location.

`GetItemLocation` is something I need for #44 .

Other changes are to adhere to the project's coding standard and to facilitate unit testing.