### PR TITLE
Fix Migration3.sql and update Web server deployment docs

### DIFF
--- a/Crypter.Console/SqlScripts/Crypter/Migrations/Migration3.sql
+++ b/Crypter.Console/SqlScripts/Crypter/Migrations/Migration3.sql
@@ -43,10 +43,11 @@ BEGIN;
            ON DELETE CASCADE
    )
 
+   TABLESPACE pg_default;
+
    CREATE INDEX "Idx_UserToken_Owner" ON public."UserToken"("Owner");
 
-   ALTER TABLE IF EXISTS public."UserToken"
-    OWNER to postgres;
+   ALTER TABLE IF EXISTS public."UserToken" OWNER to postgres;
 
    GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE public."UserToken" TO cryptuser;
 

--- a/Docs/Production/Configurations/nginx_config
+++ b/Docs/Production/Configurations/nginx_config
@@ -1,4 +1,12 @@
 server {
+  listen         80 default_server;
+  listen         [::]:80 default_server;
+
+  server_name    "";
+  return         444;
+}
+
+server {
   # do not listen to port 80 here
   listen                443 ssl http2;
   listen                [::]:443 ssl http2;

--- a/Docs/Production/Deployment/Crypter.API.md
+++ b/Docs/Production/Deployment/Crypter.API.md
@@ -42,3 +42,10 @@ Steps:
 4. Check the status of the service `sudo systemctl status kestrel-crypter.api.service`
 
 The service will automatically start up after a reboot.
+
+## Notes
+
+Running the application is not the same thing as making the application publicly available.
+
+To make the API available to the internet, follow the steps in the [Crypter.Web.md](.\Crypter.Web.md) deployment guide.
+That guide will walk you through setting up Nginx, which will proxy incoming requests to the running API.

--- a/Docs/Production/Deployment/Crypter.Web.md
+++ b/Docs/Production/Deployment/Crypter.Web.md
@@ -34,6 +34,15 @@ The Nginx configuration is checked in to source control at [..\Configurations\ng
 
 Steps:
 
-* Copy the `nginx_config` to `/etc/nginx/sites-available/crypter`
+1. Copy the `nginx_config` to `/etc/nginx/sites-available`
+2. Rename the `nginx_config` file to `crypter`
+3. Create a symlink to `/etc/nginx/sites-enabled`
+   * `sudo ln -s /etc/nginx/sites-available/crypter /etc/nginx/sites-enabled/crypter`
+4. Remove the `default` config from `sites-enabled`, if it exists. This is usually just a symlink to a file in `sites-available`
+   * `sudo rm /etc/nginx/sites-enabled/default`
+5. Test the configuration
+   * `sudo nginx -t`
 
-**Note:** `./crypter` in the above filepath is a file.  It is not a directory.
+## Notes
+
+This guide does not cover Let's Encrypt or Certbot, which are required to get host Crypter and does have an impact on the Nginx setup.


### PR DESCRIPTION
While updating the site this past weekend, the `Migration3.sql` script failed.  I failed to define a tablespace when creating the "UserToken" table.  Resolve #198 

Added more detail to the Crypter.API and Crypter.Web deployment docs.

Updated the nginx config file.