### PR TITLE
Make the file size limit more configurable

### DIFF
--- a/Crypter.Web/Crypter.Web.csproj
+++ b/Crypter.Web/Crypter.Web.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
   </ItemGroup>
 

--- a/Crypter.Web/Models/AppSettings.cs
+++ b/Crypter.Web/Models/AppSettings.cs
@@ -26,12 +26,13 @@
 
 namespace Crypter.Web.Models
 {
-    /// <summary>
-    /// Caution!  Do not add secrets here!
-    /// These settings are available to the client.
-    /// </summary>
-    public class AppSettings
-    {
-        public string ApiBaseUrl { get; set; }
-    }
+   /// <summary>
+   /// Caution!  Do not add secrets here!
+   /// These settings are available to the client.
+   /// </summary>
+   public class AppSettings
+   {
+      public string ApiBaseUrl { get; set; }
+      public int MaxUploadSizeMB { get; set; }
+   }
 }

--- a/Crypter.Web/appsettings.json
+++ b/Crypter.Web/appsettings.json
@@ -1,3 +1,4 @@
 ﻿{
-    "ApiBaseUrl": "https://localhost:44324/api"
+   "ApiBaseUrl": "https://localhost:44324/api",
+   "MaxUploadSizeMB": 1
 }


### PR DESCRIPTION
Resolve #182 

The appsettings.json file for Crypter.Web now has a setting to configure the file size limit.