### PR TITLE
Use interfaces for MessageTransfer and FileTransfer

### DIFF
--- a/Crypter.API/Controllers/MetricsController.cs
+++ b/Crypter.API/Controllers/MetricsController.cs
@@ -38,12 +38,12 @@ namespace Crypter.API.Controllers
    public class MetricsController : ControllerBase
    {
       private readonly long AllocatedDiskSpace;
-      private readonly IBaseTransferService<MessageTransfer> _messageService;
-      private readonly IBaseTransferService<FileTransfer> _fileService;
+      private readonly IBaseTransferService<IMessageTransferItem> _messageService;
+      private readonly IBaseTransferService<IFileTransferItem> _fileService;
 
       public MetricsController(IConfiguration configuration,
-          IBaseTransferService<MessageTransfer> messageService,
-          IBaseTransferService<FileTransfer> fileService
+          IBaseTransferService<IMessageTransferItem> messageService,
+          IBaseTransferService<IFileTransferItem> fileService
           )
       {
          AllocatedDiskSpace = long.Parse(configuration["EncryptedFileStore:AllocatedGB"]) * 1024 * 1024 * 1024;

--- a/Crypter.API/Controllers/TransferController.cs
+++ b/Crypter.API/Controllers/TransferController.cs
@@ -27,7 +27,6 @@
 using Crypter.API.Services;
 using Crypter.Contracts.Requests;
 using Crypter.Core.Interfaces;
-using Crypter.Core.Models;
 using Crypter.CryptoLib.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
@@ -45,8 +44,8 @@ namespace Crypter.API.Controllers
       private readonly ITokenService _tokenService;
 
       public TransferController(IConfiguration configuration,
-          IBaseTransferService<MessageTransfer> messageService,
-          IBaseTransferService<FileTransfer> fileService,
+          IBaseTransferService<IMessageTransferItem> messageService,
+          IBaseTransferService<IFileTransferItem> fileService,
           IUserService userService,
           IUserProfileService userProfileService,
           IEmailService emailService,

--- a/Crypter.API/Controllers/UserController.cs
+++ b/Crypter.API/Controllers/UserController.cs
@@ -59,8 +59,8 @@ namespace Crypter.API.Controllers
       private readonly IUserPrivacySettingService _userPrivacySettingService;
       private readonly IUserEmailVerificationService _userEmailVerificationService;
       private readonly IUserNotificationSettingService _userNotificationSettingService;
-      private readonly IBaseTransferService<MessageTransfer> _messageTransferService;
-      private readonly IBaseTransferService<FileTransfer> _fileTransferService;
+      private readonly IBaseTransferService<IMessageTransferItem> _messageTransferService;
+      private readonly IBaseTransferService<IFileTransferItem> _fileTransferService;
       private readonly IEmailService _emailService;
       private readonly IApiValidationService _apiValidationService;
       private readonly ITokenService _tokenService;
@@ -74,8 +74,8 @@ namespace Crypter.API.Controllers
           IUserPrivacySettingService userPrivacySettingService,
           IUserEmailVerificationService userEmailVerificationService,
           IUserNotificationSettingService userNotificationSettingService,
-          IBaseTransferService<MessageTransfer> messageService,
-          IBaseTransferService<FileTransfer> fileService,
+          IBaseTransferService<IMessageTransferItem> messageService,
+          IBaseTransferService<IFileTransferItem> fileService,
           IEmailService emailService,
           IApiValidationService apiValidationService,
           ITokenService tokenService

--- a/Crypter.API/Services/ApiValidationService.cs
+++ b/Crypter.API/Services/ApiValidationService.cs
@@ -28,7 +28,6 @@ using Crypter.Common.Services;
 using Crypter.Contracts.Enum;
 using Crypter.Contracts.Requests;
 using Crypter.Core.Interfaces;
-using Crypter.Core.Models;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -43,10 +42,10 @@ namespace Crypter.API.Services
    public class ApiValidationService : IApiValidationService
    {
       private readonly IUserService UserService;
-      private readonly IBaseTransferService<MessageTransfer> MessageTransferService;
-      private readonly IBaseTransferService<FileTransfer> FileTransferService;
+      private readonly IBaseTransferService<IMessageTransferItem> MessageTransferService;
+      private readonly IBaseTransferService<IFileTransferItem> FileTransferService;
 
-      public ApiValidationService(IUserService userService, IBaseTransferService<MessageTransfer> messageTransferService, IBaseTransferService<FileTransfer> fileTransferService)
+      public ApiValidationService(IUserService userService, IBaseTransferService<IMessageTransferItem> messageTransferService, IBaseTransferService<IFileTransferItem> fileTransferService)
       {
          UserService = userService;
          MessageTransferService = messageTransferService;

--- a/Crypter.API/Services/DownloadService.cs
+++ b/Crypter.API/Services/DownloadService.cs
@@ -28,7 +28,6 @@ using Crypter.Contracts.Enum;
 using Crypter.Contracts.Requests;
 using Crypter.Contracts.Responses;
 using Crypter.Core.Interfaces;
-using Crypter.Core.Models;
 using Crypter.Core.Services;
 using Crypter.CryptoLib.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -41,8 +40,8 @@ namespace Crypter.API.Services
 {
    public class DownloadService
    {
-      private readonly IBaseTransferService<MessageTransfer> MessageService;
-      private readonly IBaseTransferService<FileTransfer> FileService;
+      private readonly IBaseTransferService<IMessageTransferItem> MessageService;
+      private readonly IBaseTransferService<IFileTransferItem> FileService;
       private readonly IUserService UserService;
       private readonly IUserProfileService UserProfileService;
       private readonly ITransferItemStorageService MessageTransferItemStorageService;
@@ -53,8 +52,8 @@ namespace Crypter.API.Services
 
       public DownloadService(
          IConfiguration configuration,
-         IBaseTransferService<MessageTransfer> messageService,
-         IBaseTransferService<FileTransfer> fileService,
+         IBaseTransferService<IMessageTransferItem> messageService,
+         IBaseTransferService<IFileTransferItem> fileService,
          IUserService userService,
          IUserProfileService userProfileService,
          ISimpleEncryptionService simpleEncryptionService,

--- a/Crypter.API/Services/EmailService.cs
+++ b/Crypter.API/Services/EmailService.cs
@@ -29,7 +29,6 @@ using Crypter.API.Models;
 using Crypter.Common.Services;
 using Crypter.Contracts.Enum;
 using Crypter.Core.Interfaces;
-using Crypter.Core.Models;
 using Crypter.CryptoLib;
 using Crypter.CryptoLib.Crypto;
 using MailKit.Net.Smtp;
@@ -58,11 +57,11 @@ namespace Crypter.API.Services
       private readonly IUserService UserService;
       private readonly IUserEmailVerificationService UserEmailVerificationService;
       private readonly IUserNotificationSettingService UserNotificationSettingService;
-      private readonly IBaseTransferService<MessageTransfer> MessageTransferService;
-      private readonly IBaseTransferService<FileTransfer> FileTransferService;
+      private readonly IBaseTransferService<IMessageTransferItem> MessageTransferService;
+      private readonly IBaseTransferService<IFileTransferItem> FileTransferService;
 
       public EmailService(EmailSettings emailSettings, IUserService userService, IUserEmailVerificationService userEmailVerificationService, IUserNotificationSettingService userNotificationSettingService,
-         IBaseTransferService<MessageTransfer> messageTransferService, IBaseTransferService<FileTransfer> fileTransferService)
+         IBaseTransferService<IMessageTransferItem> messageTransferService, IBaseTransferService<IFileTransferItem> fileTransferService)
       {
          Settings = emailSettings;
          UserService = userService;

--- a/Crypter.API/Services/UploadService.cs
+++ b/Crypter.API/Services/UploadService.cs
@@ -45,8 +45,8 @@ namespace Crypter.API.Services
       private readonly long AllocatedDiskSpace;
       private readonly int MaxUploadSize;
 
-      private readonly IBaseTransferService<MessageTransfer> MessageTransferService;
-      private readonly IBaseTransferService<FileTransfer> FileTransferService;
+      private readonly IBaseTransferService<IMessageTransferItem> MessageTransferService;
+      private readonly IBaseTransferService<IFileTransferItem> FileTransferService;
       private readonly IEmailService EmailService;
       private readonly IApiValidationService ApiValidationService;
       private readonly ITransferItemStorageService MessageTransferItemStorageService;
@@ -57,8 +57,8 @@ namespace Crypter.API.Services
 
       public UploadService(
          IConfiguration configuration,
-         IBaseTransferService<MessageTransfer> messageTransferService,
-         IBaseTransferService<FileTransfer> fileTransferService,
+         IBaseTransferService<IMessageTransferItem> messageTransferService,
+         IBaseTransferService<IFileTransferItem> fileTransferService,
          IEmailService emailService,
          IApiValidationService apiValidationService,
          ISimpleEncryptionService simpleEncryptionService,
@@ -78,7 +78,7 @@ namespace Crypter.API.Services
          ItemDigestFunction = SimpleHashService.DigestSha256;
       }
 
-      private async Task<(UploadResult Result, BaseTransfer GenericTransferData, byte[] ServerEncryptedCipherText)> ReceiveTransferAsync(ITransferRequest request, Guid senderId, Guid recipientId, CancellationToken cancellationToken)
+      private async Task<(UploadResult Result, IBaseTransferItem GenericTransferData, byte[] ServerEncryptedCipherText)> ReceiveTransferAsync(ITransferRequest request, Guid senderId, Guid recipientId, CancellationToken cancellationToken)
       {
          var serverHasSpaceRemaining = await ApiValidationService.IsEnoughSpaceForNewTransferAsync(AllocatedDiskSpace, MaxUploadSize, cancellationToken);
          if (!serverHasSpaceRemaining)

--- a/Crypter.API/Startup.cs
+++ b/Crypter.API/Startup.cs
@@ -71,8 +71,8 @@ namespace CrypterAPI
          services.AddScoped<IUserEmailVerificationService, UserEmailVerificationService>();
          services.AddScoped<IUserNotificationSettingService, UserNotificationSettingService>();
          services.AddScoped<IUserTokenService, UserTokenService>();
-         services.AddScoped<IBaseTransferService<MessageTransfer>, MessageTransferItemService>();
-         services.AddScoped<IBaseTransferService<FileTransfer>, FileTransferItemService>();
+         services.AddScoped<IBaseTransferService<IMessageTransferItem>, MessageTransferItemService>();
+         services.AddScoped<IBaseTransferService<IFileTransferItem>, FileTransferItemService>();
          services.AddScoped<ISchemaService, SchemaService>();
 
          var tokenSettings = Configuration.GetSection("TokenSettings").Get<TokenSettings>();

--- a/Crypter.Console/Jobs/DeleteExpired.cs
+++ b/Crypter.Console/Jobs/DeleteExpired.cs
@@ -26,7 +26,6 @@
 
 using Crypter.Contracts.Enum;
 using Crypter.Core.Interfaces;
-using Crypter.Core.Models;
 using Crypter.Core.Services;
 using Microsoft.Extensions.Logging;
 using System;
@@ -37,11 +36,11 @@ namespace Crypter.Console.Jobs
    internal class DeleteExpired
    {
       private string FileStorePath { get; }
-      private IBaseTransferService<MessageTransfer> MessageService { get; }
-      private IBaseTransferService<FileTransfer> FileService { get; }
+      private IBaseTransferService<IMessageTransferItem> MessageService { get; }
+      private IBaseTransferService<IFileTransferItem> FileService { get; }
       private readonly ILogger<DeleteExpired> Logger;
 
-      public DeleteExpired(string fileStorePath, IBaseTransferService<MessageTransfer> messageService, IBaseTransferService<FileTransfer> fileService, ILogger<DeleteExpired> logger)
+      public DeleteExpired(string fileStorePath, IBaseTransferService<IMessageTransferItem> messageService, IBaseTransferService<IFileTransferItem> fileService, ILogger<DeleteExpired> logger)
       {
          FileStorePath = fileStorePath;
          MessageService = messageService;
@@ -55,7 +54,7 @@ namespace Crypter.Console.Jobs
 
          var messageStorageService = new TransferItemStorageService(FileStorePath, TransferItemType.Message);
          var expiredMessages = await MessageService.FindExpiredAsync(default);
-         foreach (MessageTransfer expiredItem in expiredMessages)
+         foreach (var expiredItem in expiredMessages)
          {
             Logger.LogInformation($"Deleting message {expiredItem.Id}");
             await MessageService.DeleteAsync(expiredItem.Id, default);
@@ -65,7 +64,7 @@ namespace Crypter.Console.Jobs
 
          var fileStorageService = new TransferItemStorageService(FileStorePath, TransferItemType.File);
          var expiredFiles = await FileService.FindExpiredAsync(default);
-         foreach (FileTransfer expiredItem in expiredFiles)
+         foreach (var expiredItem in expiredFiles)
          {
             Logger.LogInformation($"Deleting file {expiredItem.Id}");
             await FileService.DeleteAsync(expiredItem.Id, default);

--- a/Crypter.Console/Program.cs
+++ b/Crypter.Console/Program.cs
@@ -27,7 +27,6 @@
 using Crypter.Console.Jobs;
 using Crypter.Core;
 using Crypter.Core.Interfaces;
-using Crypter.Core.Models;
 using Crypter.Core.Services.DataAccess;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -48,8 +47,8 @@ namespace Crypter.Console
             .AddLogging(configure => configure.AddConsole())
             .AddSingleton(configuration)
             .AddSingleton<DataContext>()
-            .AddSingleton<IBaseTransferService<MessageTransfer>, MessageTransferItemService>()
-            .AddSingleton<IBaseTransferService<FileTransfer>, FileTransferItemService>()
+            .AddSingleton<IBaseTransferService<IMessageTransferItem>, MessageTransferItemService>()
+            .AddSingleton<IBaseTransferService<IFileTransferItem>, FileTransferItemService>()
             .BuildServiceProvider();
 
          if (args == null || args.Length == 0 || HelpRequired(args[0]))
@@ -61,8 +60,8 @@ namespace Crypter.Console
          if (RequestDeleteExpired(args[0]))
          {
             var deleteJob = new DeleteExpired(configuration["EncryptedFileStore"],
-               serviceProvider.GetService<IBaseTransferService<MessageTransfer>>(),
-               serviceProvider.GetService<IBaseTransferService<FileTransfer>>(),
+               serviceProvider.GetService<IBaseTransferService<IMessageTransferItem>>(),
+               serviceProvider.GetService<IBaseTransferService<IFileTransferItem>>(),
                serviceProvider.GetService<ILogger<DeleteExpired>>());
 
             await deleteJob.RunAsync();

--- a/Crypter.Core/Interfaces/DataModel/IFileTransferItem.cs
+++ b/Crypter.Core/Interfaces/DataModel/IFileTransferItem.cs
@@ -24,22 +24,11 @@
  * Contact the current copyright holder to discuss commerical license options.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Crypter.Core.Interfaces
 {
-   public interface IBaseTransferService<T> where T : IBaseTransferItem
+   public interface IFileTransferItem : IBaseTransferItem
    {
-      Task InsertAsync(T item, CancellationToken cancellationToken);
-      Task<T> ReadAsync(Guid id, CancellationToken cancellationToken);
-      Task DeleteAsync(Guid id, CancellationToken cancellationToken);
-
-      Task<IEnumerable<T>> FindBySenderAsync(Guid senderId, CancellationToken cancellationToken);
-      Task<IEnumerable<T>> FindByRecipientAsync(Guid recipientId, CancellationToken cancellationToken);
-      Task<IEnumerable<T>> FindExpiredAsync(CancellationToken cancellationToken);
-      Task<long> GetAggregateSizeAsync(CancellationToken cancellationToken);
+      string FileName { get; set; }
+      string ContentType { get; set; }
    }
 }

--- a/Crypter.Core/Interfaces/DataModel/IMessageTransferItem.cs
+++ b/Crypter.Core/Interfaces/DataModel/IMessageTransferItem.cs
@@ -24,22 +24,10 @@
  * Contact the current copyright holder to discuss commerical license options.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Crypter.Core.Interfaces
 {
-   public interface IBaseTransferService<T> where T : IBaseTransferItem
+   public interface IMessageTransferItem : IBaseTransferItem
    {
-      Task InsertAsync(T item, CancellationToken cancellationToken);
-      Task<T> ReadAsync(Guid id, CancellationToken cancellationToken);
-      Task DeleteAsync(Guid id, CancellationToken cancellationToken);
-
-      Task<IEnumerable<T>> FindBySenderAsync(Guid senderId, CancellationToken cancellationToken);
-      Task<IEnumerable<T>> FindByRecipientAsync(Guid recipientId, CancellationToken cancellationToken);
-      Task<IEnumerable<T>> FindExpiredAsync(CancellationToken cancellationToken);
-      Task<long> GetAggregateSizeAsync(CancellationToken cancellationToken);
+      string Subject { get; set; }
    }
 }

--- a/Crypter.Core/Models/BaseTransfer.cs
+++ b/Crypter.Core/Models/BaseTransfer.cs
@@ -29,6 +29,9 @@ using System;
 
 namespace Crypter.Core.Models
 {
+   /// <summary>
+   /// This class does not represent an entity tracked in the database.
+   /// </summary>
    public class BaseTransfer : IBaseTransferItem
    {
       public Guid Id { get; set; }
@@ -44,7 +47,7 @@ namespace Crypter.Core.Models
       public DateTime Created { get; set; }
       public DateTime Expiration { get; set; }
 
-      public BaseTransfer(Guid id, Guid sender, Guid recipient, int size, string clientIV, string signature, string dhPublicKeyBase64, string dsaPublicKeyBase64, byte[] serverIV, byte[] serverDigest, DateTime created, DateTime expiration)
+      public BaseTransfer(Guid id, Guid sender, Guid recipient, int size, string clientIV, string signature, string x25519PublicKey, string ed25519PublicKey, byte[] serverIV, byte[] serverDigest, DateTime created, DateTime expiration)
       {
          Id = id;
          Sender = sender;
@@ -52,8 +55,8 @@ namespace Crypter.Core.Models
          Size = size;
          ClientIV = clientIV;
          Signature = signature;
-         X25519PublicKey = dhPublicKeyBase64;
-         Ed25519PublicKey = dsaPublicKeyBase64;
+         X25519PublicKey = x25519PublicKey;
+         Ed25519PublicKey = ed25519PublicKey;
          ServerIV = serverIV;
          ServerDigest = serverDigest;
          Created = created;

--- a/Crypter.Core/Models/FileTransfer.cs
+++ b/Crypter.Core/Models/FileTransfer.cs
@@ -24,22 +24,48 @@
  * Contact the current copyright holder to discuss commerical license options.
  */
 
+using Crypter.Core.Interfaces;
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Crypter.Core.Models
 {
    [Table("FileTransfer")]
-   public class FileTransfer : BaseTransfer
+   public class FileTransfer : IFileTransferItem
    {
+      [Key]
+      public Guid Id { get; set; }
+      public Guid Sender { get; set; }
+      public Guid Recipient { get; set; }
       public string FileName { get; set; }
       public string ContentType { get; set; }
+      public int Size { get; set; }
+      public string ClientIV { get; set; }
+      public string Signature { get; set; }
+      public string X25519PublicKey { get; set; }
+      public string Ed25519PublicKey { get; set; }
+      public byte[] ServerIV { get; set; }
+      public byte[] ServerDigest { get; set; }
+      public DateTime Created { get; set; }
+      public DateTime Expiration { get; set; }
 
       public FileTransfer(Guid id, Guid sender, Guid recipient, string fileName, string contentType, int size, string clientIV, string signature, string x25519PublicKey, string ed25519PublicKey, byte[] serverIV, byte[] serverDigest, DateTime created, DateTime expiration)
-         : base(id, sender, recipient, size, clientIV, signature, x25519PublicKey, ed25519PublicKey, serverIV, serverDigest, created, expiration)
       {
+         Id = id;
+         Sender = sender;
+         Recipient = recipient;
          FileName = fileName;
          ContentType = contentType;
+         Size = size;
+         ClientIV = clientIV;
+         Signature = signature;
+         X25519PublicKey = x25519PublicKey;
+         Ed25519PublicKey = ed25519PublicKey;
+         ServerIV = serverIV;
+         ServerDigest = serverDigest;
+         Created = created;
+         Expiration = expiration;
       }
    }
 }

--- a/Crypter.Core/Models/MessageTransfer.cs
+++ b/Crypter.Core/Models/MessageTransfer.cs
@@ -24,20 +24,46 @@
  * Contact the current copyright holder to discuss commerical license options.
  */
 
+using Crypter.Core.Interfaces;
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Crypter.Core.Models
 {
    [Table("MessageTransfer")]
-   public class MessageTransfer : BaseTransfer
+   public class MessageTransfer : IMessageTransferItem
    {
+      [Key]
+      public Guid Id { get; set; }
+      public Guid Sender { get; set; }
+      public Guid Recipient { get; set; }
       public string Subject { get; set; }
+      public int Size { get; set; }
+      public string ClientIV { get; set; }
+      public string Signature { get; set; }
+      public string X25519PublicKey { get; set; }
+      public string Ed25519PublicKey { get; set; }
+      public byte[] ServerIV { get; set; }
+      public byte[] ServerDigest { get; set; }
+      public DateTime Created { get; set; }
+      public DateTime Expiration { get; set; }
 
       public MessageTransfer(Guid id, Guid sender, Guid recipient, string subject, int size, string clientIV, string signature, string x25519PublicKey, string ed25519PublicKey, byte[] serverIV, byte[] serverDigest, DateTime created, DateTime expiration)
-         : base(id, sender, recipient, size, clientIV, signature, x25519PublicKey, ed25519PublicKey, serverIV, serverDigest, created, expiration)
       {
+         Id = id;
+         Sender = sender;
+         Recipient = recipient;
          Subject = subject;
+         Size = size;
+         ClientIV = clientIV;
+         Signature = signature;
+         X25519PublicKey = x25519PublicKey;
+         Ed25519PublicKey = ed25519PublicKey;
+         ServerIV = serverIV;
+         ServerDigest = serverDigest;
+         Created = created;
+         Expiration = expiration;
       }
    }
 }

--- a/Crypter.Core/Services/DataAccess/FileTransferItemService.cs
+++ b/Crypter.Core/Services/DataAccess/FileTransferItemService.cs
@@ -35,7 +35,7 @@ using System.Threading.Tasks;
 
 namespace Crypter.Core.Services.DataAccess
 {
-   public class FileTransferItemService : IBaseTransferService<FileTransfer>
+   public class FileTransferItemService : IBaseTransferService<IFileTransferItem>
    {
       private readonly DataContext Context;
 
@@ -44,13 +44,13 @@ namespace Crypter.Core.Services.DataAccess
          Context = context;
       }
 
-      public async Task InsertAsync(FileTransfer item, CancellationToken cancellationToken)
+      public async Task InsertAsync(IFileTransferItem item, CancellationToken cancellationToken)
       {
-         Context.FileTransfer.Add(item);
+         Context.FileTransfer.Add((FileTransfer)item);
          await Context.SaveChangesAsync(cancellationToken);
       }
 
-      public async Task<FileTransfer> ReadAsync(Guid id, CancellationToken cancellationToken)
+      public async Task<IFileTransferItem> ReadAsync(Guid id, CancellationToken cancellationToken)
       {
          return await Context.FileTransfer
              .FindAsync(new object[] { id }, cancellationToken);
@@ -62,21 +62,21 @@ namespace Crypter.Core.Services.DataAccess
              .ExecuteSqlRawAsync("DELETE FROM \"FileTransfer\" WHERE \"FileTransfer\".\"Id\" = {0}", new object[] { id }, cancellationToken);
       }
 
-      public async Task<IEnumerable<FileTransfer>> FindBySenderAsync(Guid senderId, CancellationToken cancellationToken)
+      public async Task<IEnumerable<IFileTransferItem>> FindBySenderAsync(Guid senderId, CancellationToken cancellationToken)
       {
          return await Context.FileTransfer
              .Where(x => x.Sender == senderId)
              .ToListAsync(cancellationToken);
       }
 
-      public async Task<IEnumerable<FileTransfer>> FindByRecipientAsync(Guid recipientId, CancellationToken cancellationToken)
+      public async Task<IEnumerable<IFileTransferItem>> FindByRecipientAsync(Guid recipientId, CancellationToken cancellationToken)
       {
          return await Context.FileTransfer
              .Where(x => x.Recipient == recipientId)
              .ToListAsync(cancellationToken);
       }
 
-      public async Task<IEnumerable<FileTransfer>> FindExpiredAsync(CancellationToken cancellationToken)
+      public async Task<IEnumerable<IFileTransferItem>> FindExpiredAsync(CancellationToken cancellationToken)
       {
          return await Context.FileTransfer
              .Where(x => x.Expiration < DateTime.UtcNow)

--- a/Crypter.Core/Services/DataAccess/MessageTransferItemService.cs
+++ b/Crypter.Core/Services/DataAccess/MessageTransferItemService.cs
@@ -35,7 +35,7 @@ using System.Threading.Tasks;
 
 namespace Crypter.Core.Services.DataAccess
 {
-   public class MessageTransferItemService : IBaseTransferService<MessageTransfer>
+   public class MessageTransferItemService : IBaseTransferService<IMessageTransferItem>
    {
       private readonly DataContext Context;
 
@@ -44,13 +44,13 @@ namespace Crypter.Core.Services.DataAccess
          Context = context;
       }
 
-      public async Task InsertAsync(MessageTransfer item, CancellationToken cancellationToken)
+      public async Task InsertAsync(IMessageTransferItem item, CancellationToken cancellationToken)
       {
-         Context.MessageTransfer.Add(item);
+         Context.MessageTransfer.Add((MessageTransfer)item);
          await Context.SaveChangesAsync(cancellationToken);
       }
 
-      public async Task<MessageTransfer> ReadAsync(Guid id, CancellationToken cancellationToken)
+      public async Task<IMessageTransferItem> ReadAsync(Guid id, CancellationToken cancellationToken)
       {
          return await Context.MessageTransfer
              .FindAsync(new object[] { id }, cancellationToken);
@@ -62,21 +62,21 @@ namespace Crypter.Core.Services.DataAccess
              .ExecuteSqlRawAsync("DELETE FROM \"MessageTransfer\" WHERE \"MessageTransfer\".\"Id\" = {0}", new object[] { id }, cancellationToken);
       }
 
-      public async Task<IEnumerable<MessageTransfer>> FindBySenderAsync(Guid ownerId, CancellationToken cancellationToken)
+      public async Task<IEnumerable<IMessageTransferItem>> FindBySenderAsync(Guid ownerId, CancellationToken cancellationToken)
       {
          return await Context.MessageTransfer
              .Where(x => x.Sender == ownerId)
              .ToListAsync(cancellationToken);
       }
 
-      public async Task<IEnumerable<MessageTransfer>> FindByRecipientAsync(Guid recipientId, CancellationToken cancellationToken)
+      public async Task<IEnumerable<IMessageTransferItem>> FindByRecipientAsync(Guid recipientId, CancellationToken cancellationToken)
       {
          return await Context.MessageTransfer
              .Where(x => x.Recipient == recipientId)
              .ToListAsync(cancellationToken);
       }
 
-      public async Task<IEnumerable<MessageTransfer>> FindExpiredAsync(CancellationToken cancellationToken)
+      public async Task<IEnumerable<IMessageTransferItem>> FindExpiredAsync(CancellationToken cancellationToken)
       {
          return await Context.MessageTransfer
              .Where(x => x.Expiration < DateTime.UtcNow)

--- a/Crypter.Test/API_Tests/EmailService_Tests.cs
+++ b/Crypter.Test/API_Tests/EmailService_Tests.cs
@@ -67,8 +67,8 @@ namespace Crypter.Test.API_Tests
             .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
-         var mockMessageTransferService = new Mock<IBaseTransferService<MessageTransfer>>();
-         var mockFileTransferService = new Mock<IBaseTransferService<FileTransfer>>();
+         var mockMessageTransferService = new Mock<IBaseTransferService<IMessageTransferItem>>();
+         var mockFileTransferService = new Mock<IBaseTransferService<IFileTransferItem>>();
 
          var emailService = new Mock<EmailService>(_emailSettings, mockUserService.Object, mockUserEmailVerificationService.Object,
             mockNotificationService.Object, mockMessageTransferService.Object, mockFileTransferService.Object)
@@ -98,8 +98,8 @@ namespace Crypter.Test.API_Tests
             .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
-         var mockMessageTransferService = new Mock<IBaseTransferService<MessageTransfer>>();
-         var mockFileTransferService = new Mock<IBaseTransferService<FileTransfer>>();
+         var mockMessageTransferService = new Mock<IBaseTransferService<IMessageTransferItem>>();
+         var mockFileTransferService = new Mock<IBaseTransferService<IFileTransferItem>>();
 
          var emailService = new Mock<EmailService>(_emailSettings, mockUserService.Object, mockUserEmailVerificationService.Object,
             mockNotificationService.Object, mockMessageTransferService.Object, mockFileTransferService.Object)
@@ -129,8 +129,8 @@ namespace Crypter.Test.API_Tests
             .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
-         var mockMessageTransferService = new Mock<IBaseTransferService<MessageTransfer>>();
-         var mockFileTransferService = new Mock<IBaseTransferService<FileTransfer>>();
+         var mockMessageTransferService = new Mock<IBaseTransferService<IMessageTransferItem>>();
+         var mockFileTransferService = new Mock<IBaseTransferService<IFileTransferItem>>();
 
          var emailService = new Mock<EmailService>(_emailSettings, mockUserService.Object, mockUserEmailVerificationService.Object,
             mockNotificationService.Object, mockMessageTransferService.Object, mockFileTransferService.Object)
@@ -160,8 +160,8 @@ namespace Crypter.Test.API_Tests
             .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
-         var mockMessageTransferService = new Mock<IBaseTransferService<MessageTransfer>>();
-         var mockFileTransferService = new Mock<IBaseTransferService<FileTransfer>>();
+         var mockMessageTransferService = new Mock<IBaseTransferService<IMessageTransferItem>>();
+         var mockFileTransferService = new Mock<IBaseTransferService<IFileTransferItem>>();
 
          var emailService = new Mock<EmailService>(_emailSettings, mockUserService.Object, mockUserEmailVerificationService.Object,
             mockNotificationService.Object, mockMessageTransferService.Object, mockFileTransferService.Object)
@@ -193,8 +193,8 @@ namespace Crypter.Test.API_Tests
             .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => userVerification);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
-         var mockMessageTransferService = new Mock<IBaseTransferService<MessageTransfer>>();
-         var mockFileTransferService = new Mock<IBaseTransferService<FileTransfer>>();
+         var mockMessageTransferService = new Mock<IBaseTransferService<IMessageTransferItem>>();
+         var mockFileTransferService = new Mock<IBaseTransferService<IFileTransferItem>>();
 
          var emailService = new Mock<EmailService>(_emailSettings, mockUserService.Object, mockUserEmailVerificationService.Object,
             mockNotificationService.Object, mockMessageTransferService.Object, mockFileTransferService.Object)
@@ -224,8 +224,8 @@ namespace Crypter.Test.API_Tests
             .ReturnsAsync((Guid userId, CancellationToken cancellationToken) => null);
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
-         var mockMessageTransferService = new Mock<IBaseTransferService<MessageTransfer>>();
-         var mockFileTransferService = new Mock<IBaseTransferService<FileTransfer>>();
+         var mockMessageTransferService = new Mock<IBaseTransferService<IMessageTransferItem>>();
+         var mockFileTransferService = new Mock<IBaseTransferService<IFileTransferItem>>();
 
          var emailService = new Mock<EmailService>(_emailSettings, mockUserService.Object, mockUserEmailVerificationService.Object,
             mockNotificationService.Object, mockMessageTransferService.Object, mockFileTransferService.Object)
@@ -246,8 +246,8 @@ namespace Crypter.Test.API_Tests
          var mockUserEmailVerificationService = new Mock<IUserEmailVerificationService>();
 
          var mockNotificationService = new Mock<IUserNotificationSettingService>();
-         var mockMessageTransferService = new Mock<IBaseTransferService<MessageTransfer>>();
-         var mockFileTransferService = new Mock<IBaseTransferService<FileTransfer>>();
+         var mockMessageTransferService = new Mock<IBaseTransferService<IMessageTransferItem>>();
+         var mockFileTransferService = new Mock<IBaseTransferService<IFileTransferItem>>();
 
          var emailService = new Mock<EmailService>(_emailSettings, mockUserService.Object, mockUserEmailVerificationService.Object,
             mockNotificationService.Object, mockMessageTransferService.Object, mockFileTransferService.Object)


### PR DESCRIPTION
This is a non-functional change.  While looking at the Crypter.Core code, I noticed the `MessageTransfer` and `FileTransfer` classes were not using any data annotations.  Since we are using data annotations every else to define things such as primary keys and table names, I wanted to make these classes consistent.  The best way I could do that is by having those classes implement an interface and stop inheriting from a base class.

I did not need to refer to the new interfaces all over the rest of the code base, but I chose to do the work anyway.