### PR TITLE
Use MediatR to get disk metrics

### DIFF
--- a/Crypter.Contracts/Features/Metrics/Disk/DiskMetricsResponse.cs
+++ b/Crypter.Contracts/Features/Metrics/Disk/DiskMetricsResponse.cs
@@ -31,11 +31,11 @@ namespace Crypter.Contracts.Features.Metrics.Disk
    public class DiskMetricsResponse
    {
       public bool Full { get; set; }
-      public string Allocated { get; set; }
-      public string Available { get; set; }
+      public long Allocated { get; set; }
+      public long Available { get; set; }
 
       [JsonConstructor]
-      public DiskMetricsResponse(bool full, string allocated, string available)
+      public DiskMetricsResponse(bool full, long allocated, long available)
       {
          Full = full;
          Allocated = allocated;

--- a/Crypter.Core/Services/DataAccess/FileTransferItemService.cs
+++ b/Crypter.Core/Services/DataAccess/FileTransferItemService.cs
@@ -82,11 +82,5 @@ namespace Crypter.Core.Services.DataAccess
              .Where(x => x.Expiration < DateTime.UtcNow)
              .ToListAsync(cancellationToken);
       }
-
-      public async Task<long> GetAggregateSizeAsync(CancellationToken cancellationToken)
-      {
-         return await Context.FileTransfers
-             .SumAsync(x => x.Size, cancellationToken);
-      }
    }
 }

--- a/Crypter.Core/Services/DataAccess/MessageTransferItemService.cs
+++ b/Crypter.Core/Services/DataAccess/MessageTransferItemService.cs
@@ -82,11 +82,5 @@ namespace Crypter.Core.Services.DataAccess
              .Where(x => x.Expiration < DateTime.UtcNow)
              .ToListAsync(cancellationToken);
       }
-
-      public async Task<long> GetAggregateSizeAsync(CancellationToken cancellationToken)
-      {
-         return await Context.MessageTransfers
-             .SumAsync(x => x.Size, cancellationToken);
-      }
    }
 }

--- a/Crypter.Web/Shared/ServerDiskSpaceComponent.razor.cs
+++ b/Crypter.Web/Shared/ServerDiskSpaceComponent.razor.cs
@@ -45,8 +45,8 @@ namespace Crypter.Web.Shared
             left => false,
             right =>
             {
-               var allocatedServerSpace = double.Parse(right.Allocated);
-               var availableServerSpace = double.Parse(right.Available);
+               var allocatedServerSpace = (double)right.Allocated;
+               var availableServerSpace = (double)right.Available;
                ServerSpacePercentageRemaining = 100.00 * (availableServerSpace / allocatedServerSpace);
                return !right.Full;
             });


### PR DESCRIPTION
Replace existing code that gets the sum of FileTransfer.Size and MessageTransfer.Size with a MediatR query.

This also fixes the issue where sending `long` over the wire was not working properly.