### PR TITLE
Switch to master key encryption to support recovery key implementation

### DIFF
--- a/Crypter.API/Controllers/AuthenticationController.cs
+++ b/Crypter.API/Controllers/AuthenticationController.cs
@@ -176,7 +176,7 @@ namespace Crypter.API.Controllers
       [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ErrorResponse))]
       [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(void))]
       [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ErrorResponse))]
-      public async Task<IActionResult> Logout(CancellationToken cancellationToken)
+      public async Task<IActionResult> LogoutAsync(CancellationToken cancellationToken)
       {
          IActionResult MakeErrorResponse(LogoutError error)
          {
@@ -196,6 +196,39 @@ namespace Crypter.API.Controllers
             MakeErrorResponse,
             Ok,
             MakeErrorResponse(LogoutError.UnknownError));
+      }
+
+      /// <summary>
+      /// 
+      /// </summary>
+      /// <param name="request"></param>
+      /// <param name="cancellationToken"></param>
+      /// <returns></returns>
+      [HttpPost("password/test")]
+      [Authorize]
+      [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(TestPasswordResponse))]
+      [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ErrorResponse))]
+      [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(void))]
+      public async Task<IActionResult> TestPasswordAsync([FromBody] TestPasswordRequest request, CancellationToken cancellationToken)
+      {
+         IActionResult MakeErrorResponse(TestPasswordError error)
+         {
+            var errorResponse = new ErrorResponse(error);
+#pragma warning disable CS8524
+            return error switch
+            {
+               TestPasswordError.UnknownError => ServerError(errorResponse),
+               TestPasswordError.InvalidPassword => BadRequest(errorResponse)
+            };
+#pragma warning restore CS8524
+         }
+
+         var testPasswordResult = await _userAuthenticationService.TestUserPasswordAsync(User, request, cancellationToken);
+
+         return testPasswordResult.Match(
+            MakeErrorResponse,
+            Ok,
+            MakeErrorResponse(TestPasswordError.UnknownError));
       }
    }
 }

--- a/Crypter.API/Controllers/KeyController.cs
+++ b/Crypter.API/Controllers/KeyController.cs
@@ -48,6 +48,42 @@ namespace Crypter.API.Controllers
          _tokenService = tokenService;
       }
 
+      [HttpGet("master")]
+      [Authorize]
+      [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(GetMasterKeyResponse))]
+      [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(void))]
+      [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ErrorResponse))]
+      [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ErrorResponse))]
+      public async Task<IActionResult> GetMasterKeyAsync(CancellationToken cancellationToken)
+      {
+         IActionResult MakeErrorResponse(GetMasterKeyError error)
+         {
+            var errorResponse = new ErrorResponse(error);
+#pragma warning disable CS8524
+            return error switch
+            {
+               GetMasterKeyError.UnknownError => ServerError(errorResponse),
+               GetMasterKeyError.NotFound => NotFound(errorResponse)
+            };
+#pragma warning restore CS8524
+         }
+
+         var userId = _tokenService.ParseUserId(User);
+         var result = await _userKeysService.GetMasterKeyAsync(userId, cancellationToken);
+         return result.Match(
+            MakeErrorResponse,
+            Ok,
+            MakeErrorResponse(GetMasterKeyError.UnknownError));
+      }
+
+      [HttpPut("master")]
+      [Authorize]
+      [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(UpsertMasterKeyResponse))]
+      [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(void))]
+      [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrorResponse))]
+      [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ErrorResponse))]
+
+
       [HttpGet("diffie-hellman/private")]
       [Authorize]
       [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(GetPrivateKeyResponse))]
@@ -78,30 +114,29 @@ namespace Crypter.API.Controllers
 
       [HttpPut("diffie-hellman")]
       [Authorize]
-      [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(InsertKeyPairResponse))]
+      [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(UpsertKeyPairResponse))]
       [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(void))]
       [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrorResponse))]
       [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ErrorResponse))]
-      public async Task<IActionResult> InsertDiffieHellmanKeysAsync([FromBody] InsertKeyPairRequest body, CancellationToken cancellationToken)
+      public async Task<IActionResult> UpsertDiffieHellmanKeysAsync([FromBody] UpsertKeyPairRequest body, CancellationToken cancellationToken)
       {
-         IActionResult MakeErrorResponse(InsertKeyPairError error)
+         IActionResult MakeErrorResponse(UpsertKeyPairError error)
          {
             var errorResponse = new ErrorResponse(error);
 #pragma warning disable CS8524
             return error switch
             {
-               InsertKeyPairError.UnknownError => ServerError(errorResponse),
-               InsertKeyPairError.KeyPairAlreadyExists => Conflict(errorResponse),
+               UpsertKeyPairError.UnknownError => ServerError(errorResponse)
             };
 #pragma warning restore CS8524
          }
 
          var userId = _tokenService.ParseUserId(User);
-         var result = await _userKeysService.InsertDiffieHellmanKeyPairAsync(userId, body, cancellationToken);
+         var result = await _userKeysService.UpsertDiffieHellmanKeyPairAsync(userId, body, cancellationToken);
          return result.Match(
             MakeErrorResponse,
             Ok,
-            MakeErrorResponse(InsertKeyPairError.UnknownError));
+            MakeErrorResponse(UpsertKeyPairError.UnknownError));
       }
 
       [HttpGet("digital-signature/private")]
@@ -134,30 +169,29 @@ namespace Crypter.API.Controllers
 
       [HttpPut("digital-signature")]
       [Authorize]
-      [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(InsertKeyPairResponse))]
+      [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(UpsertKeyPairResponse))]
       [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(void))]
       [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrorResponse))]
       [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ErrorResponse))]
-      public async Task<IActionResult> InsertDigitalSignatureKeysAsync([FromBody] InsertKeyPairRequest body, CancellationToken cancellationToken)
+      public async Task<IActionResult> UpsertDigitalSignatureKeysAsync([FromBody] UpsertKeyPairRequest body, CancellationToken cancellationToken)
       {
-         IActionResult MakeErrorResponse(InsertKeyPairError error)
+         IActionResult MakeErrorResponse(UpsertKeyPairError error)
          {
             var errorResponse = new ErrorResponse(error);
 #pragma warning disable CS8524
             return error switch
             {
-               InsertKeyPairError.UnknownError => ServerError(errorResponse),
-               InsertKeyPairError.KeyPairAlreadyExists => Conflict(errorResponse),
+               UpsertKeyPairError.UnknownError => ServerError(errorResponse)
             };
 #pragma warning restore CS8524
          }
 
          var userId = _tokenService.ParseUserId(User);
-         var result = await _userKeysService.InsertDigitalSignatureKeyPairAsync(userId, body, cancellationToken);
+         var result = await _userKeysService.UpsertDigitalSignatureKeyPairAsync(userId, body, cancellationToken);
          return result.Match(
             MakeErrorResponse,
             Ok,
-            MakeErrorResponse(InsertKeyPairError.UnknownError));
+            MakeErrorResponse(UpsertKeyPairError.UnknownError));
       }
    }
 }

--- a/Crypter.ClientServices/Interfaces/Events/UserPasswordTestSuccessEventArgs.cs
+++ b/Crypter.ClientServices/Interfaces/Events/UserPasswordTestSuccessEventArgs.cs
@@ -24,17 +24,19 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System;
+using Crypter.Common.Primitives;
 
-namespace Crypter.Core.Entities.Interfaces
+namespace Crypter.ClientServices.Interfaces.Events
 {
-   public interface IUserPublicKeyPair
+   public class UserPasswordTestSuccessEventArgs
    {
-      public Guid Owner { get; set; }
-      public string PrivateKey { get; set; }
-      public string PublicKey { get; set; }
-      public string ClientIV { get; set; }
-      public DateTime Updated { get; set; }
-      public DateTime Created { get; set; }
+      public Username Username { get; init; }
+      public Password Password { get; init; }
+
+      public UserPasswordTestSuccessEventArgs(Username username, Password password)
+      {
+         Username = username;
+         Password = password;
+      }
    }
 }

--- a/Crypter.ClientServices/Interfaces/ICrypterApiService.cs
+++ b/Crypter.ClientServices/Interfaces/ICrypterApiService.cs
@@ -44,9 +44,10 @@ namespace Crypter.ClientServices.Interfaces
 
       #region Authentication
       Task<Either<RegistrationError, RegistrationResponse>> RegisterUserAsync(RegistrationRequest registerRequest);
-      Task<Either<LoginError, LoginResponse>>LoginAsync(LoginRequest loginRequest);
-      Task<Either<RefreshError, RefreshResponse>>RefreshAsync();
-      Task<Either<LogoutError, LogoutResponse>>LogoutAsync();
+      Task<Either<LoginError, LoginResponse>> LoginAsync(LoginRequest loginRequest);
+      Task<Either<TestPasswordError, TestPasswordResponse>> TestPasswordAsync(TestPasswordRequest testPasswordRequest);
+      Task<Either<RefreshError, RefreshResponse>> RefreshAsync();
+      Task<Either<LogoutError, LogoutResponse>> LogoutAsync();
       #endregion
 
       #region Contacts
@@ -66,10 +67,12 @@ namespace Crypter.ClientServices.Interfaces
       #endregion
 
       #region Keys
+      Task<Either<GetMasterKeyError, GetMasterKeyResponse>> GetMasterKeyAsync();
+      Task<Either<UpsertMasterKeyError, UpsertMasterKeyResponse>> UpsertMasterKeyAsync(UpsertMasterKeyRequest request);
       Task<Either<GetPrivateKeyError, GetPrivateKeyResponse>> GetDiffieHellmanPrivateKeyAsync();
-      Task<Either<InsertKeyPairError, InsertKeyPairResponse>> InsertDiffieHellmanKeysAsync(InsertKeyPairRequest request);
+      Task<Either<UpsertKeyPairError, UpsertKeyPairResponse>> UpsertDiffieHellmanKeysAsync(UpsertKeyPairRequest request);
       Task<Either<GetPrivateKeyError, GetPrivateKeyResponse>> GetDigitalSignaturePrivateKeyAsync();
-      Task<Either<InsertKeyPairError, InsertKeyPairResponse>> InsertDigitalSignatureKeysAsync(InsertKeyPairRequest request);
+      Task<Either<UpsertKeyPairError, UpsertKeyPairResponse>> UpsertDigitalSignatureKeysAsync(UpsertKeyPairRequest request);
       #endregion
 
       #region Message Transfer

--- a/Crypter.ClientServices/Interfaces/IUserKeysService.cs
+++ b/Crypter.ClientServices/Interfaces/IUserKeysService.cs
@@ -26,6 +26,7 @@
 
 using Crypter.Common.Monads;
 using Crypter.Common.Primitives;
+using System.Threading.Tasks;
 
 namespace Crypter.ClientServices.Interfaces
 {
@@ -36,5 +37,6 @@ namespace Crypter.ClientServices.Interfaces
 
       (PEMString PrivateKey, PEMString PublicKey) CreateX25519KeyPair();
       (PEMString PrivateKey, PEMString PublicKey) CreateEd25519KeyPair();
+      Task<Maybe<byte[]>> GetUserMasterKeyAsync(Username username, Password password);
    }
 }

--- a/Crypter.ClientServices/Interfaces/IUserSessionService.cs
+++ b/Crypter.ClientServices/Interfaces/IUserSessionService.cs
@@ -40,10 +40,12 @@ namespace Crypter.ClientServices.Interfaces
 
       Task<bool> IsLoggedInAsync();
       Task<Either<LoginError, Unit>> LoginAsync(Username username, Password password, bool rememberUser);
+      Task<bool> TestPasswordAsync(Password password);
       Task<Unit> LogoutAsync();
 
       event EventHandler<UserSessionServiceInitializedEventArgs> ServiceInitializedEventHandler;
       event EventHandler<UserLoggedInEventArgs> UserLoggedInEventHandler;
       event EventHandler UserLoggedOutEventHandler;
+      event EventHandler<UserPasswordTestSuccessEventArgs> UserPasswordTestSuccessEventHandler;
    }
 }

--- a/Crypter.ClientServices/Services/CrypterApiService.cs
+++ b/Crypter.ClientServices/Services/CrypterApiService.cs
@@ -90,6 +90,15 @@ namespace Crypter.ClientServices.Services
                 select errorableResponse;
       }
 
+      public Task<Either<TestPasswordError, TestPasswordResponse>> TestPasswordAsync(TestPasswordRequest testPasswordRequest)
+      {
+         string url = $"{_baseApiUrl}/authentication/password/test";
+         return from response in Either<TestPasswordError, (HttpStatusCode httpStatus, Either<ErrorResponse, TestPasswordResponse> data)>.FromRightAsync(
+                     _crypterAuthenticatedHttpService.PostAsync<TestPasswordRequest, TestPasswordResponse>(url, testPasswordRequest))
+                from errorableResponse in ExtractErrorCode<TestPasswordError, TestPasswordResponse>(response.data).AsTask()
+                select errorableResponse;
+      }
+
       public async Task<Either<RefreshError, RefreshResponse>> RefreshAsync()
       {
          string url = $"{_baseApiUrl}/authentication/refresh";
@@ -226,6 +235,24 @@ namespace Crypter.ClientServices.Services
 
       #region Keys
 
+      public Task<Either<GetMasterKeyError, GetMasterKeyResponse>> GetMasterKeyAsync()
+      {
+         string url = $"{_baseApiUrl}/keys/master";
+         return from response in Either<GetMasterKeyError, (HttpStatusCode httpStatus, Either<ErrorResponse, GetMasterKeyResponse> data)>.FromRightAsync(
+                  _crypterAuthenticatedHttpService.GetAsync<GetMasterKeyResponse>(url))
+                from errorableResponse in ExtractErrorCode<GetMasterKeyError, GetMasterKeyResponse>(response.data).AsTask()
+                select errorableResponse;
+      }
+
+      public Task<Either<UpsertMasterKeyError, UpsertMasterKeyResponse>> UpsertMasterKeyAsync(UpsertMasterKeyRequest request)
+      {
+         string url = $"{_baseApiUrl}/keys/master";
+         return from response in Either<UpsertMasterKeyError, (HttpStatusCode httpStatus, Either<ErrorResponse, UpsertMasterKeyResponse> data)>.FromRightAsync(
+                  _crypterAuthenticatedHttpService.PutAsync<UpsertMasterKeyRequest, UpsertMasterKeyResponse>(url, request))
+                from errorableResponse in ExtractErrorCode<UpsertMasterKeyError, UpsertMasterKeyResponse>(response.data).AsTask()
+                select errorableResponse;
+      }
+
       public Task<Either<GetPrivateKeyError, GetPrivateKeyResponse>> GetDiffieHellmanPrivateKeyAsync()
       {
          string url = $"{_baseApiUrl}/keys/diffie-hellman/private";
@@ -235,12 +262,12 @@ namespace Crypter.ClientServices.Services
                 select errorableResponse;
       }
 
-      public Task<Either<InsertKeyPairError, InsertKeyPairResponse>> InsertDiffieHellmanKeysAsync(InsertKeyPairRequest request)
+      public Task<Either<UpsertKeyPairError, UpsertKeyPairResponse>> UpsertDiffieHellmanKeysAsync(UpsertKeyPairRequest request)
       {
          string url = $"{_baseApiUrl}/keys/diffie-hellman";
-         return from response in Either<InsertKeyPairError, (HttpStatusCode httpStatus, Either<ErrorResponse, InsertKeyPairResponse> data)>.FromRightAsync(
-                  _crypterAuthenticatedHttpService.PutAsync<InsertKeyPairRequest, InsertKeyPairResponse>(url, request))
-                from errorableResponse in ExtractErrorCode<InsertKeyPairError, InsertKeyPairResponse>(response.data).AsTask()
+         return from response in Either<UpsertKeyPairError, (HttpStatusCode httpStatus, Either<ErrorResponse, UpsertKeyPairResponse> data)>.FromRightAsync(
+                  _crypterAuthenticatedHttpService.PutAsync<UpsertKeyPairRequest, UpsertKeyPairResponse>(url, request))
+                from errorableResponse in ExtractErrorCode<UpsertKeyPairError, UpsertKeyPairResponse>(response.data).AsTask()
                 select errorableResponse;
       }
 
@@ -253,12 +280,12 @@ namespace Crypter.ClientServices.Services
                 select errorableResponse;
       }
 
-      public Task<Either<InsertKeyPairError, InsertKeyPairResponse>> InsertDigitalSignatureKeysAsync(InsertKeyPairRequest request)
+      public Task<Either<UpsertKeyPairError, UpsertKeyPairResponse>> UpsertDigitalSignatureKeysAsync(UpsertKeyPairRequest request)
       {
          string url = $"{_baseApiUrl}/keys/digital-signature";
-         return from response in Either<InsertKeyPairError, (HttpStatusCode httpStatus, Either<ErrorResponse, InsertKeyPairResponse> data)>.FromRightAsync(
-                  _crypterAuthenticatedHttpService.PutAsync<InsertKeyPairRequest, InsertKeyPairResponse>(url, request))
-                from errorableResponse in ExtractErrorCode<InsertKeyPairError, InsertKeyPairResponse>(response.data).AsTask()
+         return from response in Either<UpsertKeyPairError, (HttpStatusCode httpStatus, Either<ErrorResponse, UpsertKeyPairResponse> data)>.FromRightAsync(
+                  _crypterAuthenticatedHttpService.PutAsync<UpsertKeyPairRequest, UpsertKeyPairResponse>(url, request))
+                from errorableResponse in ExtractErrorCode<UpsertKeyPairError, UpsertKeyPairResponse>(response.data).AsTask()
                 select errorableResponse;
       }
 

--- a/Crypter.Contracts/Features/Authentication/TestPassword/TestPasswordError.cs
+++ b/Crypter.Contracts/Features/Authentication/TestPassword/TestPasswordError.cs
@@ -24,17 +24,11 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System;
-
-namespace Crypter.Core.Entities.Interfaces
+namespace Crypter.Contracts.Features.Authentication
 {
-   public interface IUserPublicKeyPair
+   public enum TestPasswordError
    {
-      public Guid Owner { get; set; }
-      public string PrivateKey { get; set; }
-      public string PublicKey { get; set; }
-      public string ClientIV { get; set; }
-      public DateTime Updated { get; set; }
-      public DateTime Created { get; set; }
+      UnknownError,
+      InvalidPassword
    }
 }

--- a/Crypter.Contracts/Features/Authentication/TestPassword/TestPasswordRequest.cs
+++ b/Crypter.Contracts/Features/Authentication/TestPassword/TestPasswordRequest.cs
@@ -24,11 +24,27 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-namespace Crypter.Contracts.Features.Keys
+using Crypter.Common.Primitives;
+using System.Text.Json.Serialization;
+
+namespace Crypter.Contracts.Features.Authentication
 {
-   public enum InsertKeyPairError
+   public class TestPasswordRequest
    {
-      UnknownError,
-      KeyPairAlreadyExists
+      public string Username { get; init; }
+      public string Password { get; init; }
+
+      [JsonConstructor]
+      public TestPasswordRequest(string username, string password)
+      {
+         Username = username;
+         Password = password;
+      }
+
+      public TestPasswordRequest(Username username, AuthenticationPassword password)
+      {
+         Username = username.Value;
+         Password = password.Value;
+      }
    }
 }

--- a/Crypter.Contracts/Features/Authentication/TestPassword/TestPasswordResponse.cs
+++ b/Crypter.Contracts/Features/Authentication/TestPassword/TestPasswordResponse.cs
@@ -24,17 +24,9 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System;
-
-namespace Crypter.Core.Entities.Interfaces
+namespace Crypter.Contracts.Features.Authentication
 {
-   public interface IUserPublicKeyPair
+   public class TestPasswordResponse
    {
-      public Guid Owner { get; set; }
-      public string PrivateKey { get; set; }
-      public string PublicKey { get; set; }
-      public string ClientIV { get; set; }
-      public DateTime Updated { get; set; }
-      public DateTime Created { get; set; }
    }
 }

--- a/Crypter.Contracts/Features/Keys/GetMasterKey/GetMasterKeyError.cs
+++ b/Crypter.Contracts/Features/Keys/GetMasterKey/GetMasterKeyError.cs
@@ -24,17 +24,11 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System;
-
-namespace Crypter.Core.Entities.Interfaces
+namespace Crypter.Contracts.Features.Keys
 {
-   public interface IUserPublicKeyPair
+   public enum GetMasterKeyError
    {
-      public Guid Owner { get; set; }
-      public string PrivateKey { get; set; }
-      public string PublicKey { get; set; }
-      public string ClientIV { get; set; }
-      public DateTime Updated { get; set; }
-      public DateTime Created { get; set; }
+      UnknownError,
+      NotFound
    }
 }

--- a/Crypter.Contracts/Features/Keys/GetMasterKey/GetMasterKeyResponse.cs
+++ b/Crypter.Contracts/Features/Keys/GetMasterKey/GetMasterKeyResponse.cs
@@ -24,17 +24,20 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System;
+using System.Text.Json.Serialization;
 
-namespace Crypter.Core.Entities.Interfaces
+namespace Crypter.Contracts.Features.Keys
 {
-   public interface IUserPublicKeyPair
+   public class GetMasterKeyResponse
    {
-      public Guid Owner { get; set; }
-      public string PrivateKey { get; set; }
-      public string PublicKey { get; set; }
-      public string ClientIV { get; set; }
-      public DateTime Updated { get; set; }
-      public DateTime Created { get; set; }
+      public string EncryptedKey { get; init; }
+      public string ClientIV { get; init; }
+
+      [JsonConstructor]
+      public GetMasterKeyResponse(string encryptedKey, string clientIV)
+      {
+         EncryptedKey = encryptedKey;
+         ClientIV = clientIV;
+      }
    }
 }

--- a/Crypter.Contracts/Features/Keys/GetPrivateKey/GetPrivateKeyResponse.cs
+++ b/Crypter.Contracts/Features/Keys/GetPrivateKey/GetPrivateKeyResponse.cs
@@ -31,13 +31,13 @@ namespace Crypter.Contracts.Features.Keys
    public class GetPrivateKeyResponse
    {
       public string EncryptedKey { get; private set; }
-      public string IV { get; private set; }
+      public string ClientIV { get; private set; }
 
       [JsonConstructor]
-      public GetPrivateKeyResponse(string encryptedKey, string iv)
+      public GetPrivateKeyResponse(string encryptedKey, string clientIV)
       {
          EncryptedKey = encryptedKey;
-         IV = iv;
+         ClientIV = clientIV;
       }
    }
 }

--- a/Crypter.Contracts/Features/Keys/UpsertKeyPair/UpsertKeyPairError.cs
+++ b/Crypter.Contracts/Features/Keys/UpsertKeyPair/UpsertKeyPairError.cs
@@ -24,17 +24,10 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System;
-
-namespace Crypter.Core.Entities.Interfaces
+namespace Crypter.Contracts.Features.Keys
 {
-   public interface IUserPublicKeyPair
+   public enum UpsertKeyPairError
    {
-      public Guid Owner { get; set; }
-      public string PrivateKey { get; set; }
-      public string PublicKey { get; set; }
-      public string ClientIV { get; set; }
-      public DateTime Updated { get; set; }
-      public DateTime Created { get; set; }
+      UnknownError
    }
 }

--- a/Crypter.Contracts/Features/Keys/UpsertKeyPair/UpsertKeyPairRequest.cs
+++ b/Crypter.Contracts/Features/Keys/UpsertKeyPair/UpsertKeyPairRequest.cs
@@ -24,9 +24,22 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
+using System.Text.Json.Serialization;
+
 namespace Crypter.Contracts.Features.Keys
 {
-   public class InsertKeyPairResponse
+   public class UpsertKeyPairRequest
    {
+      public string EncryptedPrivateKey { get; set; }
+      public string PublicKey { get; set; }
+      public string ClientIV { get; set; }
+
+      [JsonConstructor]
+      public UpsertKeyPairRequest(string encryptedPrivateKey, string publicKey, string clientIV)
+      {
+         EncryptedPrivateKey = encryptedPrivateKey;
+         PublicKey = publicKey;
+         ClientIV = clientIV;
+      }
    }
 }

--- a/Crypter.Contracts/Features/Keys/UpsertKeyPair/UpsertKeyPairResponse.cs
+++ b/Crypter.Contracts/Features/Keys/UpsertKeyPair/UpsertKeyPairResponse.cs
@@ -24,22 +24,9 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System.Text.Json.Serialization;
-
 namespace Crypter.Contracts.Features.Keys
 {
-   public class InsertKeyPairRequest
+   public class UpsertKeyPairResponse
    {
-      public string EncryptedPrivateKeyBase64 { get; set; }
-      public string PublicKeyBase64 { get; set; }
-      public string ClientIVBase64 { get; set; }
-
-      [JsonConstructor]
-      public InsertKeyPairRequest(string encryptedPrivateKeyBase64, string publicKeyBase64, string clientIVBase64)
-      {
-         EncryptedPrivateKeyBase64 = encryptedPrivateKeyBase64;
-         PublicKeyBase64 = publicKeyBase64;
-         ClientIVBase64 = clientIVBase64;
-      }
    }
 }

--- a/Crypter.Contracts/Features/Keys/UpsertMasterKey/UpsertMasterKeyError.cs
+++ b/Crypter.Contracts/Features/Keys/UpsertMasterKey/UpsertMasterKeyError.cs
@@ -24,19 +24,10 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System;
-
-namespace Crypter.Core.Entities
+namespace Crypter.Contracts.Features.Keys
 {
-   public class SchemaEntity
+   public enum UpsertMasterKeyError
    {
-      public int Version { get; set; }
-      public DateTime Updated { get; set; }
-
-      public SchemaEntity(int version, DateTime updated)
-      {
-         Version = version;
-         Updated = updated;
-      }
+      UnknownError
    }
 }

--- a/Crypter.Contracts/Features/Keys/UpsertMasterKey/UpsertMasterKeyRequest.cs
+++ b/Crypter.Contracts/Features/Keys/UpsertMasterKey/UpsertMasterKeyRequest.cs
@@ -24,17 +24,20 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System;
+using System.Text.Json.Serialization;
 
-namespace Crypter.Core.Entities.Interfaces
+namespace Crypter.Contracts.Features.Keys
 {
-   public interface IUserPublicKeyPair
+   public class UpsertMasterKeyRequest
    {
-      public Guid Owner { get; set; }
-      public string PrivateKey { get; set; }
-      public string PublicKey { get; set; }
-      public string ClientIV { get; set; }
-      public DateTime Updated { get; set; }
-      public DateTime Created { get; set; }
+      public string EncryptedKey { get; init; }
+      public string ClientIV { get; init; }
+
+      [JsonConstructor]
+      public UpsertMasterKeyRequest(string encryptedKey, string clientIV)
+      {
+         EncryptedKey = encryptedKey;
+         ClientIV = clientIV;
+      }
    }
 }

--- a/Crypter.Contracts/Features/Keys/UpsertMasterKey/UpsertMasterKeyResponse.cs
+++ b/Crypter.Contracts/Features/Keys/UpsertMasterKey/UpsertMasterKeyResponse.cs
@@ -24,17 +24,9 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System;
-
-namespace Crypter.Core.Entities.Interfaces
+namespace Crypter.Contracts.Features.Keys
 {
-   public interface IUserPublicKeyPair
+   public class UpsertMasterKeyResponse
    {
-      public Guid Owner { get; set; }
-      public string PrivateKey { get; set; }
-      public string PublicKey { get; set; }
-      public string ClientIV { get; set; }
-      public DateTime Updated { get; set; }
-      public DateTime Created { get; set; }
    }
 }

--- a/Crypter.Core/DataContext.cs
+++ b/Crypter.Core/DataContext.cs
@@ -59,7 +59,7 @@ namespace Crypter.Core
       public DbSet<UserFileTransferEntity> UserFileTransfers { get; set; }
       public DbSet<UserMessageTransferEntity> UserMessageTransfers { get; set; }
       public DbSet<UserFailedLoginEntity> UserFailedLoginAttempts { get; set; }
-      public DbSet<SchemaEntity> Schema { get; set; }
+      public DbSet<UserMasterKeyEntity> UserMasterKeys { get; set; }
 
       protected override void OnModelCreating(ModelBuilder builder)
       {
@@ -79,7 +79,7 @@ namespace Crypter.Core
          ConfigureAnonymousMessageTransferEntity(builder);
          ConfigureAnonymousFileTransferEntity(builder);
          ConfigureUserFailedLoginEntity(builder);
-         ConfigureSchemaEntity(builder);
+         ConfigureUserMasterKeyEntity(builder);
       }
 
       private static void ConfigureUserEntity(ModelBuilder builder)
@@ -430,13 +430,19 @@ namespace Crypter.Core
             .OnDelete(DeleteBehavior.Cascade);
       }
 
-      private static void ConfigureSchemaEntity(ModelBuilder builder)
+      private static void ConfigureUserMasterKeyEntity(ModelBuilder builder)
       {
-         builder.Entity<SchemaEntity>()
-            .ToTable("Schema");
+         builder.Entity<UserMasterKeyEntity>()
+            .ToTable("UserSymmetricKey");
 
-         builder.Entity<SchemaEntity>()
-            .HasNoKey();
+         builder.Entity<UserMasterKeyEntity>()
+            .HasKey(x => x.Owner);
+
+         builder.Entity<UserMasterKeyEntity>()
+            .HasOne(x => x.User)
+            .WithOne(x => x.MasterKey)
+            .HasForeignKey<UserMasterKeyEntity>(x => x.Owner)
+            .OnDelete(DeleteBehavior.Cascade);
       }
    }
 }

--- a/Crypter.Core/Entities/UserEd25519KeyPairEntity.cs
+++ b/Crypter.Core/Entities/UserEd25519KeyPairEntity.cs
@@ -35,16 +35,18 @@ namespace Crypter.Core.Entities
       public string PrivateKey { get; set; }
       public string PublicKey { get; set; }
       public string ClientIV { get; set; }
+      public DateTime Updated { get; set; }
       public DateTime Created { get; set; }
 
       public UserEntity User { get; set; }
 
-      public UserEd25519KeyPairEntity(Guid owner, string privateKey, string publicKey, string clientIV, DateTime created)
+      public UserEd25519KeyPairEntity(Guid owner, string privateKey, string publicKey, string clientIV, DateTime updated, DateTime created)
       {
          Owner = owner;
          PrivateKey = privateKey;
          PublicKey = publicKey;
          ClientIV = clientIV;
+         Updated = updated;
          Created = created;
       }
    }

--- a/Crypter.Core/Entities/UserEntity.cs
+++ b/Crypter.Core/Entities/UserEntity.cs
@@ -48,6 +48,7 @@ namespace Crypter.Core.Entities
       public UserNotificationSettingEntity NotificationSetting { get; set; }
       public UserEd25519KeyPairEntity Ed25519KeyPair { get; set; }
       public UserX25519KeyPairEntity X25519KeyPair { get; set; }
+      public UserMasterKeyEntity MasterKey { get; set; }
       public List<UserTokenEntity> Tokens { get; set; }
       public List<UserContactEntity> Contacts { get; set; }
       public List<UserContactEntity> Contactors { get; set; }

--- a/Crypter.Core/Entities/UserMasterKeyEntity.cs
+++ b/Crypter.Core/Entities/UserMasterKeyEntity.cs
@@ -26,15 +26,25 @@
 
 using System;
 
-namespace Crypter.Core.Entities.Interfaces
+namespace Crypter.Core.Entities
 {
-   public interface IUserPublicKeyPair
+   public class UserMasterKeyEntity
    {
       public Guid Owner { get; set; }
-      public string PrivateKey { get; set; }
-      public string PublicKey { get; set; }
+      public string Key { get; set; }
       public string ClientIV { get; set; }
       public DateTime Updated { get; set; }
       public DateTime Created { get; set; }
+
+      public UserEntity User { get; set; }
+
+      public UserMasterKeyEntity(Guid owner, string key, string clientIV, DateTime updated, DateTime created)
+      {
+         Owner = owner;
+         Key = key;
+         ClientIV = clientIV;
+         Updated = updated;
+         Created = created;
+      }
    }
 }

--- a/Crypter.Core/Entities/UserX25519KeyPairEntity.cs
+++ b/Crypter.Core/Entities/UserX25519KeyPairEntity.cs
@@ -35,16 +35,18 @@ namespace Crypter.Core.Entities
       public string PrivateKey { get; set; }
       public string PublicKey { get; set; }
       public string ClientIV { get; set; }
+      public DateTime Updated { get; set; }
       public DateTime Created { get; set; }
 
       public UserEntity User { get; set; }
 
-      public UserX25519KeyPairEntity(Guid owner, string privateKey, string publicKey, string clientIV, DateTime created)
+      public UserX25519KeyPairEntity(Guid owner, string privateKey, string publicKey, string clientIV, DateTime updated, DateTime created)
       {
          Owner = owner;
          PrivateKey = privateKey;
          PublicKey = publicKey;
          ClientIV = clientIV;
+         Updated = updated;
          Created = created;
       }
    }

--- a/Crypter.Core/Services/UserKeysService.cs
+++ b/Crypter.Core/Services/UserKeysService.cs
@@ -37,10 +37,12 @@ namespace Crypter.Core.Services
 {
    public interface IUserKeysService
    {
+      Task<Either<GetMasterKeyError, GetMasterKeyResponse>> GetMasterKeyAsync(Guid userId, CancellationToken cancellationToken);
+      Task<Either<UpsertMasterKeyError, UpsertMasterKeyResponse>> UpsertMasterKeyAsync(Guid userId, UpsertMasterKeyRequest request, CancellationToken cancellationToken);
       Task<Either<GetPrivateKeyError, GetPrivateKeyResponse>> GetDiffieHellmanPrivateKeyAsync(Guid userId, CancellationToken cancellationToken);
       Task<Either<GetPrivateKeyError, GetPrivateKeyResponse>> GetDigitalSignaturePrivateKeyAsync(Guid userId, CancellationToken cancellationToken);
-      Task<Either<InsertKeyPairError, InsertKeyPairResponse>> InsertDiffieHellmanKeyPairAsync(Guid userId, InsertKeyPairRequest request, CancellationToken cancellationToken);
-      Task<Either<InsertKeyPairError, InsertKeyPairResponse>> InsertDigitalSignatureKeyPairAsync(Guid userId, InsertKeyPairRequest request, CancellationToken cancellationToken);
+      Task<Either<UpsertKeyPairError, UpsertKeyPairResponse>> UpsertDiffieHellmanKeyPairAsync(Guid userId, UpsertKeyPairRequest request, CancellationToken cancellationToken);
+      Task<Either<UpsertKeyPairError, UpsertKeyPairResponse>> UpsertDigitalSignatureKeyPairAsync(Guid userId, UpsertKeyPairRequest request, CancellationToken cancellationToken);
    }
 
    public class UserKeysService : IUserKeysService
@@ -50,6 +52,37 @@ namespace Crypter.Core.Services
       public UserKeysService(DataContext context)
       {
          _context = context;
+      }
+
+      public Task<Either<GetMasterKeyError, GetMasterKeyResponse>> GetMasterKeyAsync(Guid userId, CancellationToken cancellationToken)
+      {
+         return Either<GetMasterKeyError, GetMasterKeyResponse>.FromRightAsync(
+            _context.UserMasterKeys
+               .Where(x => x.Owner == userId)
+               .Select(x => new GetMasterKeyResponse(x.Key, x.ClientIV))
+               .FirstOrDefaultAsync(cancellationToken), GetMasterKeyError.NotFound);
+      }
+
+      public async Task<Either<UpsertMasterKeyError, UpsertMasterKeyResponse>> UpsertMasterKeyAsync(Guid userId, UpsertMasterKeyRequest request, CancellationToken cancellationToken)
+      {
+         var masterKeyEntity = await _context.UserMasterKeys
+            .FirstOrDefaultAsync(x => x.Owner == userId, cancellationToken);
+
+         DateTime now = DateTime.UtcNow;
+         if (masterKeyEntity is null)
+         {
+            var newEntity = new UserMasterKeyEntity(userId, request.EncryptedKey, request.ClientIV, now, now);
+            _context.UserMasterKeys.Add(newEntity);
+         }
+         else
+         {
+            masterKeyEntity.Key = request.EncryptedKey;
+            masterKeyEntity.ClientIV = request.ClientIV;
+            masterKeyEntity.Updated = now;
+         }
+
+         await _context.SaveChangesAsync(cancellationToken);
+         return new UpsertMasterKeyResponse();
       }
 
       public Task<Either<GetPrivateKeyError, GetPrivateKeyResponse>> GetDiffieHellmanPrivateKeyAsync(Guid userId, CancellationToken cancellationToken)
@@ -70,38 +103,50 @@ namespace Crypter.Core.Services
                .FirstOrDefaultAsync(cancellationToken), GetPrivateKeyError.NotFound);
       }
 
-      public async Task<Either<InsertKeyPairError, InsertKeyPairResponse>> InsertDiffieHellmanKeyPairAsync(Guid userId, InsertKeyPairRequest request, CancellationToken cancellationToken)
+      public async Task<Either<UpsertKeyPairError, UpsertKeyPairResponse>> UpsertDiffieHellmanKeyPairAsync(Guid userId, UpsertKeyPairRequest request, CancellationToken cancellationToken)
       {
          var keyPairEntity = await _context.UserX25519KeyPairs
             .FirstOrDefaultAsync(x => x.Owner == userId, cancellationToken);
 
+         DateTime now = DateTime.UtcNow;
          if (keyPairEntity is null)
          {
-            var newEntity = new UserX25519KeyPairEntity(userId, request.EncryptedPrivateKeyBase64, request.PublicKeyBase64, request.ClientIVBase64, DateTime.UtcNow);
+            var newEntity = new UserX25519KeyPairEntity(userId, request.EncryptedPrivateKey, request.PublicKey, request.ClientIV, now, now);
             _context.UserX25519KeyPairs.Add(newEntity);
-            await _context.SaveChangesAsync(cancellationToken);
+         }
+         else
+         {
+            keyPairEntity.PrivateKey = request.EncryptedPrivateKey;
+            keyPairEntity.PublicKey = request.PublicKey;
+            keyPairEntity.ClientIV = request.ClientIV;
+            keyPairEntity.Updated = now;
          }
 
-         return keyPairEntity is null
-            ? new InsertKeyPairResponse()
-            : InsertKeyPairError.KeyPairAlreadyExists;
+         await _context.SaveChangesAsync(cancellationToken);
+         return new UpsertKeyPairResponse();
       }
 
-      public async Task<Either<InsertKeyPairError, InsertKeyPairResponse>> InsertDigitalSignatureKeyPairAsync(Guid userId, InsertKeyPairRequest request, CancellationToken cancellationToken)
+      public async Task<Either<UpsertKeyPairError, UpsertKeyPairResponse>> UpsertDigitalSignatureKeyPairAsync(Guid userId, UpsertKeyPairRequest request, CancellationToken cancellationToken)
       {
          var keyPairEntity = await _context.UserEd25519KeyPairs
             .FirstOrDefaultAsync(x => x.Owner == userId, cancellationToken);
 
+         DateTime now = DateTime.UtcNow;
          if (keyPairEntity is null)
          {
-            var newEntity = new UserEd25519KeyPairEntity(userId, request.EncryptedPrivateKeyBase64, request.PublicKeyBase64, request.ClientIVBase64, DateTime.UtcNow);
+            var newEntity = new UserEd25519KeyPairEntity(userId, request.EncryptedPrivateKey, request.PublicKey, request.ClientIV, now, now);
             _context.UserEd25519KeyPairs.Add(newEntity);
-            await _context.SaveChangesAsync(cancellationToken);
+         }
+         else
+         {
+            keyPairEntity.PrivateKey = request.EncryptedPrivateKey;
+            keyPairEntity.PublicKey = request.PublicKey;
+            keyPairEntity.ClientIV = request.ClientIV;
+            keyPairEntity.Updated = now;
          }
 
-         return keyPairEntity is null
-            ? new InsertKeyPairResponse()
-            : InsertKeyPairError.KeyPairAlreadyExists;
+         await _context.SaveChangesAsync(cancellationToken);
+         return new UpsertKeyPairResponse();
       }
    }
 }

--- a/Crypter.CryptoLib/Services/SimpleEncryptionService.cs
+++ b/Crypter.CryptoLib/Services/SimpleEncryptionService.cs
@@ -36,6 +36,7 @@ namespace Crypter.CryptoLib.Services
 {
    public interface ISimpleEncryptionService
    {
+      byte[] GenerateKey();
       byte[] Encrypt(byte[] key, byte[] iv, byte[] plaintext);
       byte[] Encrypt(byte[] key, byte[] iv, string plaintext);
       Task<List<byte[]>> EncryptStreamAsync(byte[] key, byte[] iv, Stream stream, long streamLength, int partSize, Maybe<Func<double, Task>> progressFunc);
@@ -47,6 +48,11 @@ namespace Crypter.CryptoLib.Services
 
    public class SimpleEncryptionService : ISimpleEncryptionService
    {
+      public byte[] GenerateKey()
+      {
+         return AES.GenerateKey(Enums.AesKeySize._256).GetKey();
+      }
+
       public byte[] Encrypt(byte[] key, byte[] iv, byte[] plaintext)
       {
          var encrypter = new AES();

--- a/Crypter.Web/Pages/Authenticated/Search.razor.cs
+++ b/Crypter.Web/Pages/Authenticated/Search.razor.cs
@@ -37,7 +37,7 @@ using System.Threading.Tasks;
 
 namespace Crypter.Web.Pages
 {
-   public partial class SearchBase : AuthenticatedPageBase
+   public partial class SearchBase : AuthenticatedPageBase, IDisposable
    {
       [Inject]
       protected ICrypterApiService CrypterApiService { get; set; }

--- a/Crypter.Web/Shared/Modal/PasswordModal.razor
+++ b/Crypter.Web/Shared/Modal/PasswordModal.razor
@@ -1,0 +1,52 @@
+﻿@*
+ * Copyright (C) 2022 Crypter File Transfer
+ * 
+ * This file is part of the Crypter file transfer project.
+ * 
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ * 
+ * Contact the current copyright holder to discuss commercial license options.
+ *@
+
+@inherits PasswordModalBase
+
+<div class="modal @ModalClassPlaceholder" tabindex="-1" role="dialog" style="display:@ModalDisplayClass">
+   <div class="modal-dialog" role="document">
+      <div class="modal-content">
+         <div class="modal-header">
+            <h3>Password Required</h3>
+         </div>
+         <form @onsubmit:preventDefault @onsubmit="OnSubmitClickedAsync">
+            <div class="modal-body justify-content-center">
+               <p class="word-wrap">Provide your password to continue.</p>
+               <div class="mb-3">
+                  <input type="password" class="form-control" id="password" @bind="Password" placeholder="Password">
+                  <span hidden="@(!PasswordTestFailed)" class="text-danger">Invalid password</span>
+               </div>
+            </div>
+            <div class="modal-footer">
+               <button type="button" class="btn btn-secondary" data-dismiss="modal" @onclick="OnCancelClickedAsync">Cancel</button>
+               <button type="submit" class="btn btn-primary" data-dismiss="modal">Submit</button>
+            </div>
+         </form>
+      </div>
+   </div>
+</div>
+
+<div hidden="@(!ShowBackDrop)" class="modal-backdrop fade show"></div>

--- a/Crypter.Web/Shared/Modal/PasswordModal.razor.cs
+++ b/Crypter.Web/Shared/Modal/PasswordModal.razor.cs
@@ -1,0 +1,100 @@
+﻿/*
+ * Copyright (C) 2022 Crypter File Transfer
+ * 
+ * This file is part of the Crypter file transfer project.
+ * 
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ * 
+ * Contact the current copyright holder to discuss commercial license options.
+ */
+
+using Crypter.ClientServices.Interfaces;
+using Microsoft.AspNetCore.Components;
+using System.Threading.Tasks;
+
+namespace Crypter.Web.Shared.Modal
+{
+   public class PasswordModalBase : ComponentBase
+   {
+      [Inject]
+      private IUserSessionService UserSessionService { get; set; }
+
+      [Parameter]
+      public EventCallback<bool> ModalClosedCallback { get; set; }
+
+      protected string Username;
+
+      protected string Password;
+      protected bool PasswordTestFailed;
+
+      protected string ModalDisplayClass;
+      protected string ModalClassPlaceholder;
+      protected bool ShowBackDrop;
+
+      protected override void OnInitialized()
+      {
+         ModalDisplayClass = "none";
+      }
+
+      public void Open()
+      {
+         Username = UserSessionService.Session.Match(
+            () => string.Empty,
+            x => x.Username);
+
+         ModalDisplayClass = "block;";
+         ModalClassPlaceholder = "Show";
+         ShowBackDrop = true;
+         StateHasChanged();
+      }
+
+      public async Task CloseAsync(bool success)
+      {
+         ModalDisplayClass = "none";
+         ModalClassPlaceholder = "";
+         ShowBackDrop = false;
+         await ModalClosedCallback.InvokeAsync(success);
+      }
+
+      public async Task<bool> TestPasswordAsync()
+      {
+         if (!Common.Primitives.Password.TryFrom(Password, out var password))
+         {
+            return false;
+         }
+
+         return await UserSessionService.TestPasswordAsync(password);
+      }
+
+      public async Task OnSubmitClickedAsync()
+      {
+         if (await TestPasswordAsync())
+         {
+            await CloseAsync(true);
+         }
+
+         PasswordTestFailed = true;
+      }
+
+      public async Task OnCancelClickedAsync()
+      {
+         await CloseAsync(false);
+      }
+   }
+}

--- a/Crypter.Web/Shared/Modal/TransferSuccessModal.razor
+++ b/Crypter.Web/Shared/Modal/TransferSuccessModal.razor
@@ -41,13 +41,13 @@
                <h4>Decryption Key</h4>
                <div class="copiedTooltip">
                   <div class="input-group mb-3">
-                     <input class="form-control" value="@DecryptionKey.Value" type="text" name="privateKey" id="privateKey" readonly @onclick="CopyToClipboardAsync" />
+                     <input class="form-control" value="@DecryptionKey.Value" type="text" name="privateKey" id="privateKey" readonly />
                      <div class="input-group-append">
                         <button class="btn btn-secondary" type="button" @onclick="CopyToClipboardAsync">Copy</button>
                      </div>
                   </div>
 
-                  <span class="copiedToolTip toolTipText">Copied</span>
+                  <span id="transferSuccessCopyTooltip" class="copiedToolTip toolTipText">Copied</span>
                </div>
             </div>
             <div class="modal-footer">

--- a/Crypter.Web/Shared/Modal/TransferSuccessModal.razor.cs
+++ b/Crypter.Web/Shared/Modal/TransferSuccessModal.razor.cs
@@ -77,7 +77,7 @@ namespace Crypter.Web.Shared.Modal
 
       protected async Task CopyToClipboardAsync()
       {
-         await JSRuntime.InvokeVoidAsync("Crypter.CopyToClipboard", DecryptionKey.Value);
+         await JSRuntime.InvokeVoidAsync("Crypter.CopyToClipboard", new object[] { DecryptionKey.Value, "transferSuccessCopyTooltip" });
       }
    }
 }

--- a/Crypter.Web/Shared/UserSettings/UserSettingsKeys.razor
+++ b/Crypter.Web/Shared/UserSettings/UserSettingsKeys.razor
@@ -26,6 +26,27 @@
 
 @inherits UserSettingsKeysBase
 
+<h3>Recovery</h3>
+<div class="copiedTooltip mb-3">
+   @if (string.IsNullOrEmpty(RecoveryKey))
+   {
+      <button type="submit" class="btn btn-primary" @onclick:preventDefault @onclick="() => PasswordModal.Open()">Generate Recovery Key</button>
+   }
+   else
+   {
+      <label for="recoveryKey" class="form-label">Recovery Key</label>
+      <div class="input-group mb-3">
+         <input class="form-control" value="@RecoveryKey" type="text" id="recoveryKey" readonly />
+         <div class="input-group-append">
+            <button class="btn btn-secondary" type="button" @onclick="CopyRecoveryKeyToClipboardAsync">Copy</button>
+         </div>
+      </div>
+
+      <span id="recoveryKeyCopyTooltip" class="copiedToolTip toolTipText">Copied</span>
+   }
+</div>
+
+<h3>Transfer</h3>
 <div class="mb-3">
    <label for="ed25519PrivateKey" class="form-label">Ed25519 - Private Key</label>
    <textarea @bind="Ed25519PrivateKey" class="form-control" id="ed25519PrivateKey" disabled />
@@ -34,3 +55,5 @@
    <label for="x25519PrivateKey" class="form-label">X25519 - Private Key</label>
    <textarea @bind="X25519PrivateKey" class="form-control" id="x25519PrivateKey" disabled />
 </div>
+
+<PasswordModal @ref="PasswordModal" />

--- a/Crypter.Web/Shared/UserSettings/UserSettingsKeys.razor.cs
+++ b/Crypter.Web/Shared/UserSettings/UserSettingsKeys.razor.cs
@@ -25,17 +25,32 @@
  */
 
 using Crypter.ClientServices.Interfaces;
+using Crypter.ClientServices.Interfaces.Events;
+using Crypter.Common.Monads;
+using Crypter.Web.Shared.Modal;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using System;
+using System.Threading.Tasks;
 
 namespace Crypter.Web.Shared.UserSettings
 {
-   public partial class UserSettingsKeysBase : ComponentBase
+   public partial class UserSettingsKeysBase : ComponentBase, IDisposable
    {
       [Inject]
-      private IUserKeysService UserKeysService { get; set; }
+      protected IUserSessionService UserSessionService { get; set; }
+
+      [Inject]
+      protected IUserKeysService UserKeysService { get; set; }
+
+      [Inject]
+      protected IJSRuntime JSRuntime { get; set; }
+
+      protected PasswordModal PasswordModal { get; set; }
 
       protected string Ed25519PrivateKey;
       protected string X25519PrivateKey;
+      protected string RecoveryKey;
 
       protected override void OnInitialized()
       {
@@ -46,6 +61,31 @@ namespace Crypter.Web.Shared.UserSettings
          X25519PrivateKey = UserKeysService.X25519PrivateKey.Match(
             () => "",
             some => some.Value);
+
+         RecoveryKey = string.Empty;
+
+         UserSessionService.UserPasswordTestSuccessEventHandler += OnPasswordTestSuccess;
+      }
+
+      private async void OnPasswordTestSuccess(object sender, UserPasswordTestSuccessEventArgs args)
+      {
+         RecoveryKey = await UserKeysService.GetUserMasterKeyAsync(args.Username, args.Password)
+            .MatchAsync(
+            () => "An error occurred",
+            x => Convert.ToBase64String(x));
+
+         await InvokeAsync(() => StateHasChanged());
+      }
+
+      protected async Task CopyRecoveryKeyToClipboardAsync()
+      {
+         await JSRuntime.InvokeVoidAsync("Crypter.CopyToClipboard", new object[] { RecoveryKey, "recoveryKeyCopyTooltip" });
+      }
+
+      public void Dispose()
+      {
+         UserSessionService.UserPasswordTestSuccessEventHandler -= OnPasswordTestSuccess;
+         GC.SuppressFinalize(this);
       }
    }
 }

--- a/Crypter.Web/wwwroot/js/scripts.js
+++ b/Crypter.Web/wwwroot/js/scripts.js
@@ -1,20 +1,20 @@
 ﻿window.Crypter = {
-   CopyToClipboard: function (text) {
+   CopyToClipboard: function (textToCopy, tooltipId) {
       const animationTiming = {
          duration: 500,
          iterations: 1
       };
 
-      navigator.clipboard.writeText(text).then(() => {
-         const tooltip = document.querySelector('.toolTipText');
+      navigator.clipboard.writeText(textToCopy).then(() => {
+         const tooltip = document.getElementById(tooltipId)
          tooltip.style.display = 'block'
          tooltip.animate([{ opacity: 0 }, { opacity: 1 }], animationTiming)
             .onfinish = (e) => {
                tooltip.style.opacity = 1;
                setTimeout(() => {
-                  document.querySelector('.toolTipText').animate([{ opacity: 1 }, { opacity: 0 }], animationTiming)
+                  tooltip.animate([{ opacity: 1 }, { opacity: 0 }], animationTiming)
                      .onfinish = (e) => {
-                        document.querySelector('.toolTipText').style.display = 'none';
+                        tooltip.style.display = 'none';
                      }
                }, 500);
             }


### PR DESCRIPTION
This is a partial pull request to support the "recovery key" and "password change" features.

This pull request switches from directly encrypting a user's asymmetric private keys with `Hash(username + password)` to encrypting with a randomly generated, 256-bit key.  This random key, known as a "master" key, will be used as the user's recovery key.  Providing this master key during account recovery means we will still be able to decrypt the user's private keys even though the user lost their password.  This will be implemented in a future pull request.

Things implemented currently:

- Migrate users to the new "master key encryption" scheme during login.  The logic is: if the user has encrypted private keys, but we are unable to decrypt them using the user's master key, then they must be encrypted with the user's "credential" key.  Decrypt the private keys with the credential key, encrypt the private keys with the master key, then re-upload the newly encrypted private keys.
- Show a "Generate recovery key" field in the User Settings page.  This prompts the user for their password, sends a "test password" request to the API, and if successful, will reveal the user's master key.

These changes have been somewhat tested.  I don't intend to release until the remaining features to support account recovery and password change are done.