### PR TITLE
Remove code that would migrate user private keys to master key encryption

### DIFF
--- a/Crypter.API/Controllers/KeyController.cs
+++ b/Crypter.API/Controllers/KeyController.cs
@@ -78,7 +78,7 @@ namespace Crypter.API.Controllers
 
       [HttpPut("master")]
       [Authorize]
-      [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(UpsertMasterKeyResponse))]
+      [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(InsertMasterKeyResponse))]
       [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(void))]
       [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrorResponse))]
       [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ErrorResponse))]
@@ -114,29 +114,30 @@ namespace Crypter.API.Controllers
 
       [HttpPut("diffie-hellman")]
       [Authorize]
-      [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(UpsertKeyPairResponse))]
+      [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(InsertKeyPairResponse))]
       [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(void))]
       [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrorResponse))]
       [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ErrorResponse))]
-      public async Task<IActionResult> UpsertDiffieHellmanKeysAsync([FromBody] UpsertKeyPairRequest body, CancellationToken cancellationToken)
+      public async Task<IActionResult> UpsertDiffieHellmanKeysAsync([FromBody] InsertKeyPairRequest body, CancellationToken cancellationToken)
       {
-         IActionResult MakeErrorResponse(UpsertKeyPairError error)
+         IActionResult MakeErrorResponse(InsertKeyPairError error)
          {
             var errorResponse = new ErrorResponse(error);
 #pragma warning disable CS8524
             return error switch
             {
-               UpsertKeyPairError.UnknownError => ServerError(errorResponse)
+               InsertKeyPairError.UnknownError => ServerError(errorResponse),
+               InsertKeyPairError.Conflict => Conflict(errorResponse)
             };
 #pragma warning restore CS8524
          }
 
          var userId = _tokenService.ParseUserId(User);
-         var result = await _userKeysService.UpsertDiffieHellmanKeyPairAsync(userId, body, cancellationToken);
+         var result = await _userKeysService.InsertDiffieHellmanKeyPairAsync(userId, body, cancellationToken);
          return result.Match(
             MakeErrorResponse,
             Ok,
-            MakeErrorResponse(UpsertKeyPairError.UnknownError));
+            MakeErrorResponse(InsertKeyPairError.UnknownError));
       }
 
       [HttpGet("digital-signature/private")]
@@ -169,29 +170,30 @@ namespace Crypter.API.Controllers
 
       [HttpPut("digital-signature")]
       [Authorize]
-      [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(UpsertKeyPairResponse))]
+      [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(InsertKeyPairResponse))]
       [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(void))]
       [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ErrorResponse))]
       [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ErrorResponse))]
-      public async Task<IActionResult> UpsertDigitalSignatureKeysAsync([FromBody] UpsertKeyPairRequest body, CancellationToken cancellationToken)
+      public async Task<IActionResult> UpsertDigitalSignatureKeysAsync([FromBody] InsertKeyPairRequest body, CancellationToken cancellationToken)
       {
-         IActionResult MakeErrorResponse(UpsertKeyPairError error)
+         IActionResult MakeErrorResponse(InsertKeyPairError error)
          {
             var errorResponse = new ErrorResponse(error);
 #pragma warning disable CS8524
             return error switch
             {
-               UpsertKeyPairError.UnknownError => ServerError(errorResponse)
+               InsertKeyPairError.UnknownError => ServerError(errorResponse),
+               InsertKeyPairError.Conflict => Conflict(errorResponse)
             };
 #pragma warning restore CS8524
          }
 
          var userId = _tokenService.ParseUserId(User);
-         var result = await _userKeysService.UpsertDigitalSignatureKeyPairAsync(userId, body, cancellationToken);
+         var result = await _userKeysService.InsertDigitalSignatureKeyPairAsync(userId, body, cancellationToken);
          return result.Match(
             MakeErrorResponse,
             Ok,
-            MakeErrorResponse(UpsertKeyPairError.UnknownError));
+            MakeErrorResponse(InsertKeyPairError.UnknownError));
       }
    }
 }

--- a/Crypter.ClientServices/Interfaces/ICrypterApiService.cs
+++ b/Crypter.ClientServices/Interfaces/ICrypterApiService.cs
@@ -68,11 +68,11 @@ namespace Crypter.ClientServices.Interfaces
 
       #region Keys
       Task<Either<GetMasterKeyError, GetMasterKeyResponse>> GetMasterKeyAsync();
-      Task<Either<UpsertMasterKeyError, UpsertMasterKeyResponse>> UpsertMasterKeyAsync(UpsertMasterKeyRequest request);
+      Task<Either<InsertMasterKeyError, InsertMasterKeyResponse>> InsertMasterKeyAsync(InsertMasterKeyRequest request);
       Task<Either<GetPrivateKeyError, GetPrivateKeyResponse>> GetDiffieHellmanPrivateKeyAsync();
-      Task<Either<UpsertKeyPairError, UpsertKeyPairResponse>> UpsertDiffieHellmanKeysAsync(UpsertKeyPairRequest request);
+      Task<Either<InsertKeyPairError, InsertKeyPairResponse>> InsertDiffieHellmanKeysAsync(InsertKeyPairRequest request);
       Task<Either<GetPrivateKeyError, GetPrivateKeyResponse>> GetDigitalSignaturePrivateKeyAsync();
-      Task<Either<UpsertKeyPairError, UpsertKeyPairResponse>> UpsertDigitalSignatureKeysAsync(UpsertKeyPairRequest request);
+      Task<Either<InsertKeyPairError, InsertKeyPairResponse>> InsertDigitalSignatureKeysAsync(InsertKeyPairRequest request);
       #endregion
 
       #region Message Transfer

--- a/Crypter.ClientServices/Services/CrypterApiService.cs
+++ b/Crypter.ClientServices/Services/CrypterApiService.cs
@@ -244,12 +244,12 @@ namespace Crypter.ClientServices.Services
                 select errorableResponse;
       }
 
-      public Task<Either<UpsertMasterKeyError, UpsertMasterKeyResponse>> UpsertMasterKeyAsync(UpsertMasterKeyRequest request)
+      public Task<Either<InsertMasterKeyError, InsertMasterKeyResponse>> InsertMasterKeyAsync(InsertMasterKeyRequest request)
       {
          string url = $"{_baseApiUrl}/keys/master";
-         return from response in Either<UpsertMasterKeyError, (HttpStatusCode httpStatus, Either<ErrorResponse, UpsertMasterKeyResponse> data)>.FromRightAsync(
-                  _crypterAuthenticatedHttpService.PutAsync<UpsertMasterKeyRequest, UpsertMasterKeyResponse>(url, request))
-                from errorableResponse in ExtractErrorCode<UpsertMasterKeyError, UpsertMasterKeyResponse>(response.data).AsTask()
+         return from response in Either<InsertMasterKeyError, (HttpStatusCode httpStatus, Either<ErrorResponse, InsertMasterKeyResponse> data)>.FromRightAsync(
+                  _crypterAuthenticatedHttpService.PutAsync<InsertMasterKeyRequest, InsertMasterKeyResponse>(url, request))
+                from errorableResponse in ExtractErrorCode<InsertMasterKeyError, InsertMasterKeyResponse>(response.data).AsTask()
                 select errorableResponse;
       }
 
@@ -262,12 +262,12 @@ namespace Crypter.ClientServices.Services
                 select errorableResponse;
       }
 
-      public Task<Either<UpsertKeyPairError, UpsertKeyPairResponse>> UpsertDiffieHellmanKeysAsync(UpsertKeyPairRequest request)
+      public Task<Either<InsertKeyPairError, InsertKeyPairResponse>> InsertDiffieHellmanKeysAsync(InsertKeyPairRequest request)
       {
          string url = $"{_baseApiUrl}/keys/diffie-hellman";
-         return from response in Either<UpsertKeyPairError, (HttpStatusCode httpStatus, Either<ErrorResponse, UpsertKeyPairResponse> data)>.FromRightAsync(
-                  _crypterAuthenticatedHttpService.PutAsync<UpsertKeyPairRequest, UpsertKeyPairResponse>(url, request))
-                from errorableResponse in ExtractErrorCode<UpsertKeyPairError, UpsertKeyPairResponse>(response.data).AsTask()
+         return from response in Either<InsertKeyPairError, (HttpStatusCode httpStatus, Either<ErrorResponse, InsertKeyPairResponse> data)>.FromRightAsync(
+                  _crypterAuthenticatedHttpService.PutAsync<InsertKeyPairRequest, InsertKeyPairResponse>(url, request))
+                from errorableResponse in ExtractErrorCode<InsertKeyPairError, InsertKeyPairResponse>(response.data).AsTask()
                 select errorableResponse;
       }
 
@@ -280,12 +280,12 @@ namespace Crypter.ClientServices.Services
                 select errorableResponse;
       }
 
-      public Task<Either<UpsertKeyPairError, UpsertKeyPairResponse>> UpsertDigitalSignatureKeysAsync(UpsertKeyPairRequest request)
+      public Task<Either<InsertKeyPairError, InsertKeyPairResponse>> InsertDigitalSignatureKeysAsync(InsertKeyPairRequest request)
       {
          string url = $"{_baseApiUrl}/keys/digital-signature";
-         return from response in Either<UpsertKeyPairError, (HttpStatusCode httpStatus, Either<ErrorResponse, UpsertKeyPairResponse> data)>.FromRightAsync(
-                  _crypterAuthenticatedHttpService.PutAsync<UpsertKeyPairRequest, UpsertKeyPairResponse>(url, request))
-                from errorableResponse in ExtractErrorCode<UpsertKeyPairError, UpsertKeyPairResponse>(response.data).AsTask()
+         return from response in Either<InsertKeyPairError, (HttpStatusCode httpStatus, Either<ErrorResponse, InsertKeyPairResponse> data)>.FromRightAsync(
+                  _crypterAuthenticatedHttpService.PutAsync<InsertKeyPairRequest, InsertKeyPairResponse>(url, request))
+                from errorableResponse in ExtractErrorCode<InsertKeyPairError, InsertKeyPairResponse>(response.data).AsTask()
                 select errorableResponse;
       }
 

--- a/Crypter.ClientServices/Services/UserKeysService.cs
+++ b/Crypter.ClientServices/Services/UserKeysService.cs
@@ -174,7 +174,7 @@ namespace Crypter.ClientServices.Services
          string encodedEncryptedKey = Convert.ToBase64String(encryptedKey);
          string encodedIV = Convert.ToBase64String(iv);
 
-         return _crypterApiService.UpsertMasterKeyAsync(new UpsertMasterKeyRequest(encodedEncryptedKey, encodedIV))
+         return _crypterApiService.InsertMasterKeyAsync(new InsertMasterKeyRequest(encodedEncryptedKey, encodedIV))
             .ToMaybeTask()
             .BindAsync(x => Maybe<byte[]>.From(newMasterKey).AsTask());
       }
@@ -204,17 +204,17 @@ namespace Crypter.ClientServices.Services
          }
       }
 
-      private Task<Either<UpsertKeyPairError, UpsertKeyPairResponse>> UploadKeyPairAsync(byte[] encryptedPrivateKey, PEMString publicKey, byte[] iv, UserKeyType keyType)
+      private Task<Either<InsertKeyPairError, InsertKeyPairResponse>> UploadKeyPairAsync(byte[] encryptedPrivateKey, PEMString publicKey, byte[] iv, UserKeyType keyType)
       {
          var base64PublicKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(publicKey.Value));
          var base64EncryptedPrivateKey = Convert.ToBase64String(encryptedPrivateKey);
          var base64IV = Convert.ToBase64String(iv);
 
-         var request = new UpsertKeyPairRequest(base64EncryptedPrivateKey, base64PublicKey, base64IV);
+         var request = new InsertKeyPairRequest(base64EncryptedPrivateKey, base64PublicKey, base64IV);
          return keyType switch
          {
-            UserKeyType.Ed25519 => _crypterApiService.UpsertDigitalSignatureKeysAsync(request),
-            UserKeyType.X25519 => _crypterApiService.UpsertDiffieHellmanKeysAsync(request),
+            UserKeyType.Ed25519 => _crypterApiService.InsertDigitalSignatureKeysAsync(request),
+            UserKeyType.X25519 => _crypterApiService.InsertDiffieHellmanKeysAsync(request),
             _ => throw new NotImplementedException("Unknown key type.")
          };
       }

--- a/Crypter.Contracts/Features/Keys/InsertKeyPair/InsertKeyPairError.cs
+++ b/Crypter.Contracts/Features/Keys/InsertKeyPair/InsertKeyPairError.cs
@@ -26,8 +26,9 @@
 
 namespace Crypter.Contracts.Features.Keys
 {
-   public enum UpsertMasterKeyError
+   public enum InsertKeyPairError
    {
-      UnknownError
+      UnknownError,
+      Conflict
    }
 }

--- a/Crypter.Contracts/Features/Keys/InsertKeyPair/InsertKeyPairRequest.cs
+++ b/Crypter.Contracts/Features/Keys/InsertKeyPair/InsertKeyPairRequest.cs
@@ -24,9 +24,22 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
+using System.Text.Json.Serialization;
+
 namespace Crypter.Contracts.Features.Keys
 {
-   public class UpsertKeyPairResponse
+   public class InsertKeyPairRequest
    {
+      public string EncryptedPrivateKey { get; set; }
+      public string PublicKey { get; set; }
+      public string ClientIV { get; set; }
+
+      [JsonConstructor]
+      public InsertKeyPairRequest(string encryptedPrivateKey, string publicKey, string clientIV)
+      {
+         EncryptedPrivateKey = encryptedPrivateKey;
+         PublicKey = publicKey;
+         ClientIV = clientIV;
+      }
    }
 }

--- a/Crypter.Contracts/Features/Keys/InsertKeyPair/InsertKeyPairResponse.cs
+++ b/Crypter.Contracts/Features/Keys/InsertKeyPair/InsertKeyPairResponse.cs
@@ -24,22 +24,9 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System.Text.Json.Serialization;
-
 namespace Crypter.Contracts.Features.Keys
 {
-   public class UpsertKeyPairRequest
+   public class InsertKeyPairResponse
    {
-      public string EncryptedPrivateKey { get; set; }
-      public string PublicKey { get; set; }
-      public string ClientIV { get; set; }
-
-      [JsonConstructor]
-      public UpsertKeyPairRequest(string encryptedPrivateKey, string publicKey, string clientIV)
-      {
-         EncryptedPrivateKey = encryptedPrivateKey;
-         PublicKey = publicKey;
-         ClientIV = clientIV;
-      }
    }
 }

--- a/Crypter.Contracts/Features/Keys/InsertMasterKey/InsertMasterKeyError.cs
+++ b/Crypter.Contracts/Features/Keys/InsertMasterKey/InsertMasterKeyError.cs
@@ -26,7 +26,9 @@
 
 namespace Crypter.Contracts.Features.Keys
 {
-   public class UpsertMasterKeyResponse
+   public enum InsertMasterKeyError
    {
+      UnknownError,
+      Conflict
    }
 }

--- a/Crypter.Contracts/Features/Keys/InsertMasterKey/InsertMasterKeyRequest.cs
+++ b/Crypter.Contracts/Features/Keys/InsertMasterKey/InsertMasterKeyRequest.cs
@@ -28,13 +28,13 @@ using System.Text.Json.Serialization;
 
 namespace Crypter.Contracts.Features.Keys
 {
-   public class UpsertMasterKeyRequest
+   public class InsertMasterKeyRequest
    {
       public string EncryptedKey { get; init; }
       public string ClientIV { get; init; }
 
       [JsonConstructor]
-      public UpsertMasterKeyRequest(string encryptedKey, string clientIV)
+      public InsertMasterKeyRequest(string encryptedKey, string clientIV)
       {
          EncryptedKey = encryptedKey;
          ClientIV = clientIV;

--- a/Crypter.Contracts/Features/Keys/InsertMasterKey/InsertMasterKeyResponse.cs
+++ b/Crypter.Contracts/Features/Keys/InsertMasterKey/InsertMasterKeyResponse.cs
@@ -26,8 +26,7 @@
 
 namespace Crypter.Contracts.Features.Keys
 {
-   public enum UpsertKeyPairError
+   public class InsertMasterKeyResponse
    {
-      UnknownError
    }
 }


### PR DESCRIPTION
Rather than re-encrypt private keys when the user logs in for the first time, following this update, I am just going to delete all asymmetric key pairs from the database.  Realistically, this will not result in any sort of data loss as long as there are no transfers currently stored on the server.  Users will generate new keys when they login again.