### PR TITLE
Properly delete user transfers which have anonymous recipients

### DIFF
--- a/Crypter.Core/Services/HangfireBackgroundService.cs
+++ b/Crypter.Core/Services/HangfireBackgroundService.cs
@@ -40,7 +40,21 @@ namespace Crypter.Core.Services
    {
       Task SendEmailVerificationAsync(Guid userId, CancellationToken cancellationToken);
       Task SendTransferNotificationAsync(Guid itemId, TransferItemType itemType, CancellationToken cancellationToken);
-      Task DeleteTransferAsync(Guid itemId, TransferItemType itemType, TransferUserType userType, CancellationToken cancellationToken);
+
+      /// <summary>
+      /// Delete a transfer from transfer storage and the database.
+      /// </summary>
+      /// <param name="itemId"></param>
+      /// <param name="itemType"></param>
+      /// <param name="userType"></param>
+      /// <param name="deleteFromTransferStorage">
+      /// Transfers are streamed from transfer storage to the client.
+      /// These streams are sometimes configured to "DeleteOnClose".
+      /// The background service should not delete from transfer storage when "DeleteOnClose" is configured.
+      /// </param>
+      /// <param name="cancellationToken"></param>
+      /// <returns></returns>
+      Task DeleteTransferAsync(Guid itemId, TransferItemType itemType, TransferUserType userType, bool deleteFromTransferStorage, CancellationToken cancellationToken);
       Task DeleteUserTokenAsync(Guid tokenId, CancellationToken cancellationToken);
       Task DeleteFailedLoginAttemptAsync(Guid failedAttemptId, CancellationToken cancellationToken);
    }
@@ -113,7 +127,7 @@ namespace Crypter.Core.Services
          await _emailService.SendTransferNotificationAsync(emailAddress, cancellationToken);
       }
 
-      public async Task DeleteTransferAsync(Guid itemId, TransferItemType itemType, TransferUserType userType, CancellationToken cancellationToken)
+      public async Task DeleteTransferAsync(Guid itemId, TransferItemType itemType, TransferUserType userType, bool deleteFromTransferStorage, CancellationToken cancellationToken)
       {
          bool entityFound = false;
 
@@ -163,7 +177,10 @@ namespace Crypter.Core.Services
             await _context.SaveChangesAsync(cancellationToken);
          }
 
-         _transferStorageService.DeleteTransfer(itemId, itemType, userType);
+         if (deleteFromTransferStorage)
+         {
+            _transferStorageService.DeleteTransfer(itemId, itemType, userType);
+         }
       }
 
       public async Task DeleteUserTokenAsync(Guid tokenId, CancellationToken cancellationToken)

--- a/Crypter.Core/Services/TransferDownloadService.cs
+++ b/Crypter.Core/Services/TransferDownloadService.cs
@@ -46,10 +46,10 @@ namespace Crypter.Core.Services
       Task<Either<DownloadTransferCiphertextError, FileStream>> GetAnonymousMessageCiphertextAsync(string hashId, DownloadTransferCiphertextRequest request, CancellationToken cancellationToken);
       Task<Either<DownloadTransferCiphertextError, FileStream>> GetAnonymousFileCiphertextAsync(string hashId, DownloadTransferCiphertextRequest request, CancellationToken cancellationToken);
 
-      Task<Either<DownloadTransferPreviewError, DownloadTransferMessagePreviewResponse>> GetUserMessagePreviewAsync(string hashId, Maybe<Guid> recipientId, CancellationToken cancellationToken);
-      Task<Either<DownloadTransferPreviewError, DownloadTransferFilePreviewResponse>> GetUserFilePreviewAsync(string hashId, Maybe<Guid> recipientId, CancellationToken cancellationToken);
-      Task<Either<DownloadTransferCiphertextError, FileStream>> GetUserMessageCiphertextAsync(string hashId, DownloadTransferCiphertextRequest request, Maybe<Guid> recipientId, CancellationToken cancellationToken);
-      Task<Either<DownloadTransferCiphertextError, FileStream>> GetUserFileCiphertextAsync(string hashId, DownloadTransferCiphertextRequest request, Maybe<Guid> recipientId, CancellationToken cancellationToken);
+      Task<Either<DownloadTransferPreviewError, DownloadTransferMessagePreviewResponse>> GetUserMessagePreviewAsync(string hashId, Maybe<Guid> requestorId, CancellationToken cancellationToken);
+      Task<Either<DownloadTransferPreviewError, DownloadTransferFilePreviewResponse>> GetUserFilePreviewAsync(string hashId, Maybe<Guid> requestorId, CancellationToken cancellationToken);
+      Task<Either<DownloadTransferCiphertextError, FileStream>> GetUserMessageCiphertextAsync(string hashId, DownloadTransferCiphertextRequest request, Maybe<Guid> requestorId, CancellationToken cancellationToken);
+      Task<Either<DownloadTransferCiphertextError, FileStream>> GetUserFileCiphertextAsync(string hashId, DownloadTransferCiphertextRequest request, Maybe<Guid> requestorId, CancellationToken cancellationToken);
    }
 
    public class TransferDownloadService : ITransferDownloadService
@@ -119,7 +119,7 @@ namespace Crypter.Core.Services
          }
 
          Maybe<FileStream> ciphertextStream = _transferStorageService.GetTransfer(id, TransferItemType.Message, TransferUserType.Anonymous, true);
-         ciphertextStream.IfSome(x => _backgroundJobClient.Schedule(() => _hangfireBackgroundService.DeleteTransferAsync(id, TransferItemType.Message, TransferUserType.Anonymous, CancellationToken.None), DateTime.UtcNow.AddMinutes(1)));
+         ciphertextStream.IfSome(_ => _backgroundJobClient.Schedule(() => _hangfireBackgroundService.DeleteTransferAsync(id, TransferItemType.Message, TransferUserType.Anonymous, CancellationToken.None), DateTime.UtcNow.AddMinutes(1)));
          return ciphertextStream.ToEither(DownloadTransferCiphertextError.NotFound);
       }
 
@@ -143,13 +143,13 @@ namespace Crypter.Core.Services
          }
 
          Maybe<FileStream> ciphertextStream = _transferStorageService.GetTransfer(id, TransferItemType.File, TransferUserType.Anonymous, true);
-         ciphertextStream.IfSome(x => _backgroundJobClient.Schedule(() => _hangfireBackgroundService.DeleteTransferAsync(id, TransferItemType.File, TransferUserType.Anonymous, CancellationToken.None), DateTime.UtcNow.AddMinutes(1)));
+         ciphertextStream.IfSome(_ => _backgroundJobClient.Schedule(() => _hangfireBackgroundService.DeleteTransferAsync(id, TransferItemType.File, TransferUserType.Anonymous, CancellationToken.None), DateTime.UtcNow.AddMinutes(1)));
          return ciphertextStream.ToEither(DownloadTransferCiphertextError.NotFound);
       }
 
-      public async Task<Either<DownloadTransferPreviewError, DownloadTransferMessagePreviewResponse>> GetUserMessagePreviewAsync(string hashId, Maybe<Guid> recipientId, CancellationToken cancellationToken)
+      public async Task<Either<DownloadTransferPreviewError, DownloadTransferMessagePreviewResponse>> GetUserMessagePreviewAsync(string hashId, Maybe<Guid> requestorId, CancellationToken cancellationToken)
       {
-         Guid? nullableRecipientUserId = recipientId.Match<Guid?>(
+         Guid? nullableRequestorUserId = requestorId.Match<Guid?>(
             () => null,
             x => x);
 
@@ -157,7 +157,7 @@ namespace Crypter.Core.Services
 
          IQueryable<UserMessageTransferEntity> baseQuery = _context.UserMessageTransfers
             .Where(x => x.Id == id)
-            .Where(x => x.RecipientId == null || x.RecipientId == nullableRecipientUserId);
+            .Where(x => x.RecipientId == null || x.RecipientId == nullableRequestorUserId);
 
          bool sentAnonymously = await baseQuery
             .Where(x => x.SenderId == null)
@@ -175,9 +175,9 @@ namespace Crypter.Core.Services
             : DownloadTransferPreviewError.NotFound;
       }
 
-      public async Task<Either<DownloadTransferPreviewError, DownloadTransferFilePreviewResponse>> GetUserFilePreviewAsync(string hashId, Maybe<Guid> recipientId, CancellationToken cancellationToken)
+      public async Task<Either<DownloadTransferPreviewError, DownloadTransferFilePreviewResponse>> GetUserFilePreviewAsync(string hashId, Maybe<Guid> requestorId, CancellationToken cancellationToken)
       {
-         Guid? nullableRecipientUserId = recipientId.Match<Guid?>(
+         Guid? nullableRequestorUserId = requestorId.Match<Guid?>(
             () => null,
             x => x);
 
@@ -185,7 +185,7 @@ namespace Crypter.Core.Services
 
          IQueryable<UserFileTransferEntity> baseQuery = _context.UserFileTransfers
             .Where(x => x.Id == id)
-            .Where(x => x.RecipientId == null || x.RecipientId == nullableRecipientUserId);
+            .Where(x => x.RecipientId == null || x.RecipientId == nullableRequestorUserId);
 
          bool sentAnonymously = await baseQuery
             .Where(x => x.SenderId == null)
@@ -203,17 +203,17 @@ namespace Crypter.Core.Services
             : DownloadTransferPreviewError.NotFound;
       }
 
-      public async Task<Either<DownloadTransferCiphertextError, FileStream>> GetUserMessageCiphertextAsync(string hashId, DownloadTransferCiphertextRequest request, Maybe<Guid> recipientId, CancellationToken cancellationToken)
+      public async Task<Either<DownloadTransferCiphertextError, FileStream>> GetUserMessageCiphertextAsync(string hashId, DownloadTransferCiphertextRequest request, Maybe<Guid> requestorId, CancellationToken cancellationToken)
       {
-         Guid? nullableRecipientUserId = recipientId.Match<Guid?>(
+         Guid? nullableRequestorUserId = requestorId.Match<Guid?>(
             () => null,
             x => x);
 
          Guid id = _hashIdService.Decode(hashId);
          var databaseData = await _context.UserMessageTransfers
             .Where(x => x.Id == id)
-            .Where(x => x.RecipientId == null || x.RecipientId == nullableRecipientUserId)
-            .Select(x => new { x.Proof })
+            .Where(x => x.RecipientId == null || x.RecipientId == nullableRequestorUserId)
+            .Select(x => new { x.RecipientId, x.Proof })
             .FirstOrDefaultAsync(cancellationToken);
 
          bool ciphertextExists = _transferStorageService.TransferExists(id, TransferItemType.Message, TransferUserType.User);
@@ -227,21 +227,29 @@ namespace Crypter.Core.Services
             return DownloadTransferCiphertextError.InvalidRecipientProof;
          }
 
-         return _transferStorageService.GetTransfer(id, TransferItemType.Message, TransferUserType.User, recipientId.IsNone)
-            .ToEither(DownloadTransferCiphertextError.NotFound);
+         bool deleteOnReadCompletion = !databaseData.RecipientId.HasValue;
+         Maybe<FileStream> ciphertextStream = _transferStorageService.GetTransfer(id, TransferItemType.Message, TransferUserType.User, deleteOnReadCompletion);
+         ciphertextStream.IfSome(_ =>
+         {
+            if (deleteOnReadCompletion)
+            {
+               _backgroundJobClient.Schedule(() => _hangfireBackgroundService.DeleteTransferAsync(id, TransferItemType.Message, TransferUserType.User, CancellationToken.None), DateTime.UtcNow.AddMinutes(1));
+            }
+         });
+         return ciphertextStream.ToEither(DownloadTransferCiphertextError.NotFound);
       }
 
-      public async Task<Either<DownloadTransferCiphertextError, FileStream>> GetUserFileCiphertextAsync(string hashId, DownloadTransferCiphertextRequest request, Maybe<Guid> recipientId, CancellationToken cancellationToken)
+      public async Task<Either<DownloadTransferCiphertextError, FileStream>> GetUserFileCiphertextAsync(string hashId, DownloadTransferCiphertextRequest request, Maybe<Guid> requestorId, CancellationToken cancellationToken)
       {
-         Guid? nullableRecipientUserId = recipientId.Match<Guid?>(
+         Guid? nullableRequestorUserId = requestorId.Match<Guid?>(
             () => null,
             x => x);
 
          Guid id = _hashIdService.Decode(hashId);
          var databaseData = await _context.UserFileTransfers
             .Where(x => x.Id == id)
-            .Where(x => x.RecipientId == null || x.RecipientId == nullableRecipientUserId)
-            .Select(x => new { x.Proof })
+            .Where(x => x.RecipientId == null || x.RecipientId == nullableRequestorUserId)
+            .Select(x => new { x.RecipientId, x.Proof })
             .FirstOrDefaultAsync(cancellationToken);
 
          bool ciphertextExists = _transferStorageService.TransferExists(id, TransferItemType.File, TransferUserType.User);
@@ -255,8 +263,16 @@ namespace Crypter.Core.Services
             return DownloadTransferCiphertextError.InvalidRecipientProof;
          }
 
-         return _transferStorageService.GetTransfer(id, TransferItemType.File, TransferUserType.User, recipientId.IsNone)
-            .ToEither(DownloadTransferCiphertextError.NotFound);
+         bool deleteOnReadCompletion = !databaseData.RecipientId.HasValue;
+         Maybe<FileStream> ciphertextStream = _transferStorageService.GetTransfer(id, TransferItemType.File, TransferUserType.User, deleteOnReadCompletion);
+         ciphertextStream.IfSome(_ =>
+         {
+            if (deleteOnReadCompletion)
+            {
+               _backgroundJobClient.Schedule(() => _hangfireBackgroundService.DeleteTransferAsync(id, TransferItemType.File, TransferUserType.User, CancellationToken.None), DateTime.UtcNow.AddMinutes(1));
+            }
+         });
+         return ciphertextStream.ToEither(DownloadTransferCiphertextError.NotFound);
       }
    }
 }


### PR DESCRIPTION
## Breaking Change

This PR contains a breaking change.  The signature for the HangfireBackgroundService's `DeleteTransferAsync` method has changed.  This change should not be deployed until all transfers have been deleted from the server.  And ideally, though not necessary, there should not be any pending jobs of this type left in the job queue.

## Description

I discovered some inconsistent behavior this evening, with respect to user-to-anonymous uploads.  The uploads are conditionally deleted based on who performs the decryption.  The item is not deleted from the database nor filesystem when decrypted by an authenticated user.  The item is only deleted from the filesystem when decrypted by an unauthenticated user - the database entry lingers until the 24-hour expiration time.

Deleting an item upon decryption should not consider who performs the decryption.  What matters is to whom the item was sent.

The desired behavior with this PR is to immediately delete items which have no particular recipient as soon as they decrypted, regardless of the decryptor's authentication status.  Items sent to particular users should only get deleted after 24 hours.