### PR TITLE
Transfer requests should succeed after a token refresh occurs

### DIFF
--- a/Crypter.Common.Client/Implementations/CrypterAuthenticatedHttpClient.cs
+++ b/Crypter.Common.Client/Implementations/CrypterAuthenticatedHttpClient.cs
@@ -224,10 +224,9 @@ namespace Crypter.Common.Client.Implementations
             _requestSemaphore.Release();
          }
 
-         HttpRequestMessage initialRequest = requestFactory();
+         using HttpRequestMessage initialRequest = requestFactory();
          await AttachTokenAsync(initialRequest, useRefreshToken);
          HttpResponseMessage initialAttempt = await _httpClient.SendAsync(initialRequest, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
-         initialRequest.Dispose();
 
          if (initialAttempt.StatusCode != HttpStatusCode.Unauthorized || useRefreshToken)
          {

--- a/Crypter.Common.Client/Implementations/CrypterAuthenticatedHttpClient.cs
+++ b/Crypter.Common.Client/Implementations/CrypterAuthenticatedHttpClient.cs
@@ -73,8 +73,8 @@ namespace Crypter.Common.Client.Implementations
       public async Task<Maybe<TResponse>> GetMaybeAsync<TResponse>(string uri)
          where TResponse : class
       {
-         var request = MakeRequestMessageFactory(HttpMethod.Get, uri);
-         using HttpResponseMessage response = await SendWithAuthenticationAsync(request, false);
+         var requestFactory = MakeRequestMessageFactory(HttpMethod.Get, uri);
+         using HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, false);
          return await DeserializeMaybeResponseAsync<TResponse>(response);
       }
 
@@ -87,46 +87,46 @@ namespace Crypter.Common.Client.Implementations
       public async Task<Either<ErrorResponse, TResponse>> GetEitherAsync<TResponse>(string uri, bool useRefreshToken = false)
          where TResponse : class
       {
-         var request = MakeRequestMessageFactory(HttpMethod.Get, uri);
-         using HttpResponseMessage response = await SendWithAuthenticationAsync(request, useRefreshToken);
+         var requestFactory = MakeRequestMessageFactory(HttpMethod.Get, uri);
+         using HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, useRefreshToken);
          return await DeserializeResponseAsync<TResponse>(response);
       }
 
       public async Task<Either<ErrorResponse, Unit>> GetEitherUnitResponseAsync(string uri)
       {
-         var request = MakeRequestMessageFactory(HttpMethod.Get, uri);
-         using HttpResponseMessage response = await SendWithAuthenticationAsync(request, false);
+         var requestFactory = MakeRequestMessageFactory(HttpMethod.Get, uri);
+         using HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, false);
          return await DeserializeEitherUnitResponseAsync(response);
       }
 
       public async Task<Either<ErrorResponse, StreamDownloadResponse>> GetStreamResponseAsync(string uri)
       {
-         var request = MakeRequestMessageFactory(HttpMethod.Get, uri);
-         HttpResponseMessage response = await SendWithAuthenticationAsync(request, false);
+         var requestFactory = MakeRequestMessageFactory(HttpMethod.Get, uri);
+         HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, false);
          return await GetStreamResponseAsync(response);
       }
 
       public async Task<Either<ErrorResponse, TResponse>> PutEitherAsync<TRequest, TResponse>(string uri, TRequest body, bool useRefreshToken = false)
          where TRequest : class
       {
-         var request = MakeRequestMessageFactory(HttpMethod.Put, uri, body);
-         using HttpResponseMessage response = await SendWithAuthenticationAsync(request, useRefreshToken);
+         var requestFactory = MakeRequestMessageFactory(HttpMethod.Put, uri, body);
+         using HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, useRefreshToken);
          return await DeserializeResponseAsync<TResponse>(response);
       }
 
       public async Task<Either<ErrorResponse, Unit>> PutEitherUnitResponseAsync<TRequest>(string uri, TRequest body, bool useRefreshToken = false)
          where TRequest : class
       {
-         var request = MakeRequestMessageFactory(HttpMethod.Put, uri, body);
-         using HttpResponseMessage response = await SendWithAuthenticationAsync(request, useRefreshToken);
+         var requestFactory = MakeRequestMessageFactory(HttpMethod.Put, uri, body);
+         using HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, useRefreshToken);
          return await DeserializeEitherUnitResponseAsync(response);
       }
 
       public async Task<Either<ErrorResponse, TResponse>> PostEitherAsync<TResponse>(string uri, bool useRefreshToken = false)
          where TResponse : class
       {
-         var request = MakeRequestMessageFactory(HttpMethod.Post, uri);
-         using HttpResponseMessage response = await SendWithAuthenticationAsync(request, useRefreshToken);
+         var requestFactory = MakeRequestMessageFactory(HttpMethod.Post, uri);
+         using HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, useRefreshToken);
          return await DeserializeResponseAsync<TResponse>(response);
       }
 
@@ -141,15 +141,15 @@ namespace Crypter.Common.Client.Implementations
          where TResponse : class
          where TRequest : class
       {
-         var request = MakeRequestMessageFactory(HttpMethod.Post, uri, body);
-         using HttpResponseMessage response = await SendWithAuthenticationAsync(request, false);
+         var requestFactory = MakeRequestMessageFactory(HttpMethod.Post, uri, body);
+         using HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, false);
          return await DeserializeResponseAsync<TResponse>(response);
       }
 
       public async Task<Maybe<Unit>> PostMaybeUnitResponseAsync(string uri)
       {
-         var request = MakeRequestMessageFactory(HttpMethod.Post, uri);
-         using HttpResponseMessage response = await SendWithAuthenticationAsync(request, false);
+         var requestFactory = MakeRequestMessageFactory(HttpMethod.Post, uri);
+         using HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, false);
          return DeserializeMaybeUnitResponseAsync(response);
       }
 
@@ -160,8 +160,8 @@ namespace Crypter.Common.Client.Implementations
 
       public async Task<Either<ErrorResponse, Unit>> PostEitherUnitResponseAsync(string uri, bool useRefreshToken = false)
       {
-         var request = MakeRequestMessageFactory(HttpMethod.Post, uri);
-         using HttpResponseMessage response = await SendWithAuthenticationAsync(request, useRefreshToken);
+         var requestFactory = MakeRequestMessageFactory(HttpMethod.Post, uri);
+         using HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, useRefreshToken);
          return await DeserializeEitherUnitResponseAsync(response);
       }
 
@@ -173,23 +173,23 @@ namespace Crypter.Common.Client.Implementations
 
       public async Task<Either<ErrorResponse, Unit>> PostUnitResponseAsync<TRequest>(string uri, bool useRefreshToken = false)
       {
-         var request = MakeRequestMessageFactory(HttpMethod.Post, uri);
-         using HttpResponseMessage response = await SendWithAuthenticationAsync(request, useRefreshToken);
+         var requestFactory = MakeRequestMessageFactory(HttpMethod.Post, uri);
+         using HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, useRefreshToken);
          return await DeserializeEitherUnitResponseAsync(response);
       }
 
       public async Task<Either<ErrorResponse, Unit>> PostEitherUnitResponseAsync<TRequest>(string uri, TRequest body, bool useRefreshToken = false)
          where TRequest : class
       {
-         var request = MakeRequestMessageFactory(HttpMethod.Post, uri, body);
-         using HttpResponseMessage response = await SendWithAuthenticationAsync(request, useRefreshToken);
+         var requestFactory = MakeRequestMessageFactory(HttpMethod.Post, uri, body);
+         using HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, useRefreshToken);
          return await DeserializeEitherUnitResponseAsync(response);
       }
 
       public async Task<Maybe<Unit>> DeleteUnitResponseAsync(string uri)
       {
-         var request = MakeRequestMessageFactory(HttpMethod.Delete, uri);
-         using HttpResponseMessage response = await SendWithAuthenticationAsync(request, false);
+         var requestFactory = MakeRequestMessageFactory(HttpMethod.Delete, uri);
+         using HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, false);
          return response.IsSuccessStatusCode
             ? Unit.Default
             : Maybe<Unit>.None;
@@ -224,9 +224,10 @@ namespace Crypter.Common.Client.Implementations
             _requestSemaphore.Release();
          }
 
-         using HttpRequestMessage initialRequest = requestFactory();
+         HttpRequestMessage initialRequest = requestFactory();
          await AttachTokenAsync(initialRequest, useRefreshToken);
          HttpResponseMessage initialAttempt = await _httpClient.SendAsync(initialRequest, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+         initialRequest.Dispose();
 
          if (initialAttempt.StatusCode != HttpStatusCode.Unauthorized || useRefreshToken)
          {
@@ -237,15 +238,16 @@ namespace Crypter.Common.Client.Implementations
             await _requestSemaphore.WaitAsync().ConfigureAwait(false);
             try
             {
-               using HttpRequestMessage retryRequest = requestFactory();
-               var refreshAndRetry = from refreshResponse in _crypterApiClient.UserAuthentication.RefreshSessionAsync()
+               HttpRequestMessage retryRequest = requestFactory();
+               var refreshAndRetry = await (from refreshResponse in _crypterApiClient.UserAuthentication.RefreshSessionAsync()
                                      from unit0 in Either<RefreshError, Unit>.FromRightAsync(_tokenRepository.StoreAuthenticationTokenAsync(refreshResponse.AuthenticationToken))
                                      from unit1 in Either<RefreshError, Unit>.FromRightAsync(_tokenRepository.StoreRefreshTokenAsync(refreshResponse.RefreshToken, refreshResponse.RefreshTokenType))
                                      from unit2 in Either<RefreshError, Unit>.FromRightAsync(AttachTokenAsync(retryRequest, false))
                                      from secondAttempt in Either<RefreshError, HttpResponseMessage>.FromRightAsync(_httpClient.SendAsync(retryRequest, HttpCompletionOption.ResponseHeadersRead))
-                                     select secondAttempt;
+                                     select secondAttempt);
 
-               return await refreshAndRetry.MatchAsync(
+               retryRequest.Dispose();
+               return refreshAndRetry.Match(
                   initialAttempt,
                   right => right);
             }

--- a/Crypter.Common.Client/Implementations/CrypterAuthenticatedHttpClient.cs
+++ b/Crypter.Common.Client/Implementations/CrypterAuthenticatedHttpClient.cs
@@ -102,7 +102,7 @@ namespace Crypter.Common.Client.Implementations
       public async Task<Either<ErrorResponse, StreamDownloadResponse>> GetStreamResponseAsync(string uri)
       {
          var requestFactory = MakeRequestMessageFactory(HttpMethod.Get, uri);
-         HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, false);
+         using HttpResponseMessage response = await SendWithAuthenticationAsync(requestFactory, false);
          return await GetStreamResponseAsync(response);
       }
 

--- a/Crypter.Common.Client/Implementations/CrypterHttpClient.cs
+++ b/Crypter.Common.Client/Implementations/CrypterHttpClient.cs
@@ -115,11 +115,11 @@ namespace Crypter.Common.Client.Implementations
             : Maybe<Unit>.None;
       }
 
-      public Task<Either<ErrorResponse, TResponse>> SendAsync<TResponse>(Func<HttpRequestMessage> requestFactory)
+      public async Task<Either<ErrorResponse, TResponse>> SendAsync<TResponse>(Func<HttpRequestMessage> requestFactory)
          where TResponse : class
       {
          using HttpRequestMessage request = requestFactory();
-         return SendRequestEitherResponseAsync<TResponse>(request);
+         return await SendRequestEitherResponseAsync<TResponse>(request);
       }
 
       private static HttpRequestMessage MakeRequestMessage<TRequest>(HttpMethod method, string uri, TRequest body)

--- a/Crypter.Common.Client/Implementations/CrypterHttpClient.cs
+++ b/Crypter.Common.Client/Implementations/CrypterHttpClient.cs
@@ -27,6 +27,7 @@
 using Crypter.Common.Client.Interfaces;
 using Crypter.Common.Contracts;
 using Crypter.Common.Monads;
+using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -115,10 +116,10 @@ namespace Crypter.Common.Client.Implementations
             : Maybe<Unit>.None;
       }
 
-      public Task<Either<ErrorResponse, TResponse>> SendAsync<TResponse>(HttpRequestMessage requestMessage)
+      public Task<Either<ErrorResponse, TResponse>> SendAsync<TResponse>(Func<HttpRequestMessage> requestFactory)
          where TResponse : class
       {
-         return SendRequestEitherResponseAsync<TResponse>(requestMessage);
+         return SendRequestEitherResponseAsync<TResponse>(requestFactory());
       }
 
       private static HttpRequestMessage MakeRequestMessage<TRequest>(HttpMethod method, string uri, TRequest body)

--- a/Crypter.Common.Client/Implementations/CrypterHttpClient.cs
+++ b/Crypter.Common.Client/Implementations/CrypterHttpClient.cs
@@ -50,65 +50,65 @@ namespace Crypter.Common.Client.Implementations
          };
       }
 
-      public Task<Maybe<TResponse>> GetMaybeAsync<TResponse>(string uri)
+      public async Task<Maybe<TResponse>> GetMaybeAsync<TResponse>(string uri)
          where TResponse : class
       {
-         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-         return SendRequestMaybeResponseAsync<TResponse>(request);
+         using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
+         return await SendRequestMaybeResponseAsync<TResponse>(request);
       }
 
-      public Task<Either<ErrorResponse, TResponse>> GetEitherAsync<TResponse>(string uri)
+      public async Task<Either<ErrorResponse, TResponse>> GetEitherAsync<TResponse>(string uri)
          where TResponse : class
       {
-         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-         return SendRequestEitherResponseAsync<TResponse>(request);
+         using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
+         return await SendRequestEitherResponseAsync<TResponse>(request);
       }
 
-      public Task<Either<ErrorResponse, Unit>> GetEitherUnitResponseAsync(string uri)
+      public async Task<Either<ErrorResponse, Unit>> GetEitherUnitResponseAsync(string uri)
       {
-         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-         return SendRequestEitherUnitResponseAsync(request);
+         using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
+         return await SendRequestEitherUnitResponseAsync(request);
       }
 
-      public Task<Either<ErrorResponse, StreamDownloadResponse>> GetStreamResponseAsync(string uri)
+      public async Task<Either<ErrorResponse, StreamDownloadResponse>> GetStreamResponseAsync(string uri)
       {
-         var request = new HttpRequestMessage(HttpMethod.Get, uri);
-         return GetStreamAsync(request);
+         using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
+         return await GetStreamAsync(request);
       }
 
-      public Task<Either<ErrorResponse, TResponse>> PostEitherAsync<TRequest, TResponse>(string uri, TRequest body)
+      public async Task<Either<ErrorResponse, TResponse>> PostEitherAsync<TRequest, TResponse>(string uri, TRequest body)
          where TResponse : class
          where TRequest : class
       {
-         var request = MakeRequestMessage(HttpMethod.Post, uri, body);
-         return SendRequestEitherResponseAsync<TResponse>(request);
+         using HttpRequestMessage request = MakeRequestMessage(HttpMethod.Post, uri, body);
+         return await SendRequestEitherResponseAsync<TResponse>(request);
       }
 
       public async Task<Maybe<Unit>> PostMaybeUnitResponseAsync(string uri)
       {
-         var request = new HttpRequestMessage(HttpMethod.Post, uri);
+         using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
          using HttpResponseMessage response = await _httpClient.SendAsync(request);
          return response.IsSuccessStatusCode
             ? Unit.Default
             : Maybe<Unit>.None;
       }
 
-      public Task<Either<ErrorResponse, Unit>> PostEitherUnitResponseAsync(string uri)
+      public async Task<Either<ErrorResponse, Unit>> PostEitherUnitResponseAsync(string uri)
       {
-         var request = new HttpRequestMessage(HttpMethod.Post, uri);
-         return SendRequestEitherUnitResponseAsync(request);
+         using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
+         return await SendRequestEitherUnitResponseAsync(request);
       }
 
-      public Task<Either<ErrorResponse, Unit>> PostEitherUnitResponseAsync<TRequest>(string uri, TRequest body)
+      public async Task<Either<ErrorResponse, Unit>> PostEitherUnitResponseAsync<TRequest>(string uri, TRequest body)
          where TRequest : class
       {
-         var request = MakeRequestMessage(HttpMethod.Post, uri, body);
-         return SendRequestEitherUnitResponseAsync(request);
+         using HttpRequestMessage request = MakeRequestMessage(HttpMethod.Post, uri, body);
+         return await SendRequestEitherUnitResponseAsync(request);
       }
 
       public async Task<Maybe<Unit>> DeleteUnitResponseAsync(string uri)
       {
-         var request = new HttpRequestMessage(HttpMethod.Post, uri);
+         using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
          using HttpResponseMessage response = await _httpClient.SendAsync(request);
          return response.IsSuccessStatusCode
             ? Unit.Default
@@ -118,7 +118,8 @@ namespace Crypter.Common.Client.Implementations
       public Task<Either<ErrorResponse, TResponse>> SendAsync<TResponse>(Func<HttpRequestMessage> requestFactory)
          where TResponse : class
       {
-         return SendRequestEitherResponseAsync<TResponse>(requestFactory());
+         using HttpRequestMessage request = requestFactory();
+         return SendRequestEitherResponseAsync<TResponse>(request);
       }
 
       private static HttpRequestMessage MakeRequestMessage<TRequest>(HttpMethod method, string uri, TRequest body)
@@ -133,7 +134,6 @@ namespace Crypter.Common.Client.Implementations
       private async Task<Maybe<TResponse>> SendRequestMaybeResponseAsync<TResponse>(HttpRequestMessage request)
       {
          using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
-         request.Dispose();
          using Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
          if (!response.IsSuccessStatusCode)
          {
@@ -146,7 +146,6 @@ namespace Crypter.Common.Client.Implementations
       private async Task<Either<ErrorResponse, TResponse>> SendRequestEitherResponseAsync<TResponse>(HttpRequestMessage request)
       {
          using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
-         request.Dispose();
          using Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
          if (!response.IsSuccessStatusCode)
          {
@@ -159,7 +158,6 @@ namespace Crypter.Common.Client.Implementations
       private async Task<Either<ErrorResponse, Unit>> SendRequestEitherUnitResponseAsync(HttpRequestMessage request)
       {
          using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
-         request.Dispose();
          using Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
          return response.IsSuccessStatusCode
             ? Unit.Default
@@ -169,7 +167,6 @@ namespace Crypter.Common.Client.Implementations
       private async Task<Either<ErrorResponse, StreamDownloadResponse>> GetStreamAsync(HttpRequestMessage request)
       {
          using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
-         request.Dispose();
          Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
          if (!response.IsSuccessStatusCode)

--- a/Crypter.Common.Client/Implementations/CrypterHttpClient.cs
+++ b/Crypter.Common.Client/Implementations/CrypterHttpClient.cs
@@ -29,7 +29,6 @@ using Crypter.Common.Contracts;
 using Crypter.Common.Monads;
 using System;
 using System.IO;
-using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -134,6 +133,7 @@ namespace Crypter.Common.Client.Implementations
       private async Task<Maybe<TResponse>> SendRequestMaybeResponseAsync<TResponse>(HttpRequestMessage request)
       {
          using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+         request.Dispose();
          using Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
          if (!response.IsSuccessStatusCode)
          {
@@ -146,6 +146,7 @@ namespace Crypter.Common.Client.Implementations
       private async Task<Either<ErrorResponse, TResponse>> SendRequestEitherResponseAsync<TResponse>(HttpRequestMessage request)
       {
          using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+         request.Dispose();
          using Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
          if (!response.IsSuccessStatusCode)
          {
@@ -158,6 +159,7 @@ namespace Crypter.Common.Client.Implementations
       private async Task<Either<ErrorResponse, Unit>> SendRequestEitherUnitResponseAsync(HttpRequestMessage request)
       {
          using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+         request.Dispose();
          using Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
          return response.IsSuccessStatusCode
             ? Unit.Default
@@ -166,7 +168,8 @@ namespace Crypter.Common.Client.Implementations
 
       private async Task<Either<ErrorResponse, StreamDownloadResponse>> GetStreamAsync(HttpRequestMessage request)
       {
-         HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+         using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+         request.Dispose();
          Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
          if (!response.IsSuccessStatusCode)

--- a/Crypter.Common.Client/Implementations/Requests/MessageTransferRequests.cs
+++ b/Crypter.Common.Client/Implementations/Requests/MessageTransferRequests.cs
@@ -51,7 +51,7 @@ namespace Crypter.Common.Client.Implementations.Requests
          _crypterAuthenticatedHttpClient = crypterAuthenticatedHttpClient;
       }
 
-      public async Task<Either<UploadTransferError, UploadTransferResponse>> UploadMessageTransferAsync(Maybe<string> recipientUsername, UploadMessageTransferRequest uploadRequest, EncryptionStream encryptionStream, bool withAuthentication)
+      public async Task<Either<UploadTransferError, UploadTransferResponse>> UploadMessageTransferAsync(Maybe<string> recipientUsername, UploadMessageTransferRequest uploadRequest, Func<EncryptionStream> encryptionStreamOpener, bool withAuthentication)
       {
          string url = recipientUsername.Match(
             () => "api/message/transfer",
@@ -61,16 +61,16 @@ namespace Crypter.Common.Client.Implementations.Requests
             ? _crypterAuthenticatedHttpClient
             : _crypterHttpClient;
 
-         using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, url)
+         HttpRequestMessage requestFactory() => new HttpRequestMessage(HttpMethod.Post, url)
          {
             Content = new MultipartFormDataContent
             {
                { new StringContent(JsonSerializer.Serialize(uploadRequest), Encoding.UTF8, "application/json"), "Data" },
-               { new StreamContent(encryptionStream), "Ciphertext", "Ciphertext" }
+               { new StreamContent(encryptionStreamOpener()), "Ciphertext", "Ciphertext" }
             }
          };
 
-         return await service.SendAsync<UploadTransferResponse>(request)
+         return await service.SendAsync<UploadTransferResponse>(requestFactory)
             .ExtractErrorCode<UploadTransferError, UploadTransferResponse>();
       }
 

--- a/Crypter.Common.Client/Interfaces/ICrypterHttpClient.cs
+++ b/Crypter.Common.Client/Interfaces/ICrypterHttpClient.cs
@@ -26,6 +26,7 @@
 
 using Crypter.Common.Contracts;
 using Crypter.Common.Monads;
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -56,7 +57,7 @@ namespace Crypter.Common.Client.Interfaces
 
       Task<Maybe<Unit>> DeleteUnitResponseAsync(string uri);
 
-      Task<Either<ErrorResponse, TResponse>> SendAsync<TResponse>(HttpRequestMessage request)
+      Task<Either<ErrorResponse, TResponse>> SendAsync<TResponse>(Func<HttpRequestMessage> requestFactory)
          where TResponse : class;
    }
 }

--- a/Crypter.Common.Client/Interfaces/Requests/IFileTransferRequests.cs
+++ b/Crypter.Common.Client/Interfaces/Requests/IFileTransferRequests.cs
@@ -28,6 +28,7 @@ using Crypter.Common.Contracts;
 using Crypter.Common.Contracts.Features.Transfer;
 using Crypter.Common.Monads;
 using Crypter.Crypto.Common.StreamEncryption;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -35,7 +36,7 @@ namespace Crypter.Common.Client.Interfaces.Requests
 {
    public interface IFileTransferRequests
    {
-      Task<Either<UploadTransferError, UploadTransferResponse>> UploadFileTransferAsync(Maybe<string> recipientUsername, UploadFileTransferRequest uploadRequest, EncryptionStream encryptionStream, bool withAuthentication);
+      Task<Either<UploadTransferError, UploadTransferResponse>> UploadFileTransferAsync(Maybe<string> recipientUsername, UploadFileTransferRequest uploadRequest, Func<EncryptionStream> encryptionStreamOpener, bool withAuthentication);
       Task<Maybe<List<UserReceivedFileDTO>>> GetReceivedFilesAsync();
       Task<Maybe<List<UserSentFileDTO>>> GetSentFilesAsync();
       Task<Either<TransferPreviewError, FileTransferPreviewResponse>> GetAnonymousFilePreviewAsync(string hashId);

--- a/Crypter.Common.Client/Interfaces/Requests/IMessageTransferRequests.cs
+++ b/Crypter.Common.Client/Interfaces/Requests/IMessageTransferRequests.cs
@@ -28,6 +28,7 @@ using Crypter.Common.Contracts;
 using Crypter.Common.Contracts.Features.Transfer;
 using Crypter.Common.Monads;
 using Crypter.Crypto.Common.StreamEncryption;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -35,7 +36,7 @@ namespace Crypter.Common.Client.Interfaces.Requests
 {
    public interface IMessageTransferRequests
    {
-      Task<Either<UploadTransferError, UploadTransferResponse>> UploadMessageTransferAsync(Maybe<string> recipientUsername, UploadMessageTransferRequest uploadRequest, EncryptionStream encryptionStream, bool withAuthentication);
+      Task<Either<UploadTransferError, UploadTransferResponse>> UploadMessageTransferAsync(Maybe<string> recipientUsername, UploadMessageTransferRequest uploadRequest, Func<EncryptionStream> encryptionStreamOpener, bool withAuthentication);
       Task<Maybe<List<UserReceivedMessageDTO>>> GetReceivedMessagesAsync();
       Task<Maybe<List<UserSentMessageDTO>>> GetSentMessagesAsync();
       Task<Either<TransferPreviewError, MessageTransferPreviewResponse>> GetAnonymousMessagePreviewAsync(string hashId);

--- a/Crypter.Common.Client/Transfer/Handlers/Base/DownloadHandler.cs
+++ b/Crypter.Common.Client/Transfer/Handlers/Base/DownloadHandler.cs
@@ -96,7 +96,7 @@ namespace Crypter.Common.Client.Transfer.Handlers.Base
 
       protected byte[] Decrypt(byte[] key, Stream ciphertext, long streamSize)
       {
-         DecryptionStream decryptionStream = new DecryptionStream(ciphertext, streamSize, key, _cryptoProvider.StreamEncryptionFactory);
+         using DecryptionStream decryptionStream = new DecryptionStream(ciphertext, streamSize, key, _cryptoProvider.StreamEncryptionFactory);
          byte[] plaintextBuffer = new byte[checked((int)streamSize)];
          int plaintextPosition = 0;
          int bytesRead;
@@ -106,7 +106,6 @@ namespace Crypter.Common.Client.Transfer.Handlers.Base
             plaintextPosition += bytesRead;
          }
          while (bytesRead > 0);
-         ciphertext.Dispose();
          return plaintextBuffer[..plaintextPosition];
       }
    }

--- a/Crypter.Common.Client/Transfer/Handlers/Base/UploadHandler.cs
+++ b/Crypter.Common.Client/Transfer/Handlers/Base/UploadHandler.cs
@@ -95,7 +95,7 @@ namespace Crypter.Common.Client.Transfer.Handlers.Base
          _recipientPublicKey = recipientKeyPair.PublicKey;
       }
 
-      protected (EncryptionStream encryptionStream, byte[] senderPublicKey, byte[] proof) GetEncryptionInfo(Stream plaintextStream, long streamSize)
+      protected (Func<EncryptionStream> encryptionStreamOpener, byte[] senderPublicKey, byte[] proof) GetEncryptionInfo(Func<Stream> plaintextStreamOpener, long streamSize)
       {
          if (_recipientUsername.IsNone)
          {
@@ -122,8 +122,10 @@ namespace Crypter.Common.Client.Transfer.Handlers.Base
             ? null
             : senderPublicKey;
 
-         EncryptionStream encryptionStream = new EncryptionStream(plaintextStream, streamSize, encryptionKey, _cryptoProvider.StreamEncryptionFactory, _transferSettings.MaxReadSize, _transferSettings.PadSize);
-         return (encryptionStream, senderPublicKeyToUpload, proof);
+         EncryptionStream encryptionStreamOpener()
+            => new EncryptionStream(plaintextStreamOpener(), streamSize, encryptionKey, _cryptoProvider.StreamEncryptionFactory, _transferSettings.MaxReadSize, _transferSettings.PadSize);
+
+         return (encryptionStreamOpener, senderPublicKeyToUpload, proof);
       }
    }
 }

--- a/Crypter.Common.Client/Transfer/TransferHandlerFactory.cs
+++ b/Crypter.Common.Client/Transfer/TransferHandlerFactory.cs
@@ -29,6 +29,7 @@ using Crypter.Common.Client.Transfer.Handlers;
 using Crypter.Common.Client.Transfer.Models;
 using Crypter.Common.Enums;
 using Crypter.Crypto.Common;
+using System;
 using System.IO;
 
 namespace Crypter.Common.Client.Transfer
@@ -49,10 +50,10 @@ namespace Crypter.Common.Client.Transfer
          _transferSettings = transferSettings;
       }
 
-      public UploadFileHandler CreateUploadFileHandler(Stream fileStream, string fileName, long fileSize, string fileContentType, int expirationHours)
+      public UploadFileHandler CreateUploadFileHandler(Func<Stream> fileStreamOpener, string fileName, long fileSize, string fileContentType, int expirationHours)
       {
          var handler = new UploadFileHandler(_crypterApiClient, _cryptoProvider, _transferSettings);
-         handler.SetTransferInfo(fileStream, fileName, fileSize, fileContentType, expirationHours);
+         handler.SetTransferInfo(fileStreamOpener, fileName, fileSize, fileContentType, expirationHours);
          return handler;
       }
 

--- a/Crypter.Crypto.Common/StreamEncryption/DecryptionStream.cs
+++ b/Crypter.Crypto.Common/StreamEncryption/DecryptionStream.cs
@@ -186,5 +186,11 @@ namespace Crypter.Crypto.Common.StreamEncryption
             throw new CryptographicException("Unexpected 'final' block");
          }
       }
+
+      protected override void Dispose(bool disposing)
+      {
+         _ciphertextStream.Dispose();
+         base.Dispose(disposing);
+      }
    }
 }

--- a/Crypter.Test/Integration_Tests/FileTransfer_Tests/DownloadFileTransfer_Tests.cs
+++ b/Crypter.Test/Integration_Tests/FileTransfer_Tests/DownloadFileTransfer_Tests.cs
@@ -84,6 +84,10 @@ namespace Crypter.Test.Integration_Tests.FileTransfer_Tests
 
          Assert.True(uploadResult.IsRight);
          Assert.True(result.IsRight);
+         result.DoRight(x =>
+         {
+            Assert.DoesNotThrow(() => x.Stream.ReadByte());
+         });
       }
 
       [TestCase(true, false)]
@@ -155,6 +159,10 @@ namespace Crypter.Test.Integration_Tests.FileTransfer_Tests
 
          Assert.True(uploadResult.IsRight);
          Assert.True(result.IsRight);
+         result.DoRight(x =>
+         {
+            Assert.DoesNotThrow(() => x.Stream.ReadByte());
+         });
       }
    }
 }

--- a/Crypter.Test/Integration_Tests/FileTransfer_Tests/DownloadFileTransfer_Tests.cs
+++ b/Crypter.Test/Integration_Tests/FileTransfer_Tests/DownloadFileTransfer_Tests.cs
@@ -34,6 +34,7 @@ using Crypter.Crypto.Common.StreamEncryption;
 using Crypter.Test.Integration_Tests.Common;
 using Microsoft.AspNetCore.Mvc.Testing;
 using NUnit.Framework;
+using System;
 using System.Threading.Tasks;
 
 namespace Crypter.Test.Integration_Tests.FileTransfer_Tests
@@ -71,9 +72,9 @@ namespace Crypter.Test.Integration_Tests.FileTransfer_Tests
       [Test]
       public async Task Download_Anonymous_File_Transfer_Works()
       {
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadFileTransferRequest uploadRequest = new UploadFileTransferRequest(TestData.DefaultTransferFileName, TestData.DefaultTransferFileContentType, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var uploadResult = await _client.FileTransfer.UploadFileTransferAsync(Maybe<string>.None, uploadRequest, encryptionStream, false);
+         var uploadResult = await _client.FileTransfer.UploadFileTransferAsync(Maybe<string>.None, uploadRequest, encryptionStreamOpener, false);
 
          string uploadId = uploadResult
             .Map(x => x.HashId)
@@ -130,9 +131,9 @@ namespace Crypter.Test.Integration_Tests.FileTransfer_Tests
             var registrationResult = await _client.UserAuthentication.RegisterAsync(registrationRequest);
          });
 
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadFileTransferRequest uploadRequest = new UploadFileTransferRequest(TestData.DefaultTransferFileName, TestData.DefaultTransferFileContentType, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var uploadResult = await _client.FileTransfer.UploadFileTransferAsync(recipientUsername, uploadRequest, encryptionStream, senderDefined);
+         var uploadResult = await _client.FileTransfer.UploadFileTransferAsync(recipientUsername, uploadRequest, encryptionStreamOpener, senderDefined);
 
          await recipientUsername.IfSomeAsync(async username =>
          {

--- a/Crypter.Test/Integration_Tests/FileTransfer_Tests/GetReceivedFileTransfers_Tests.cs
+++ b/Crypter.Test/Integration_Tests/FileTransfer_Tests/GetReceivedFileTransfers_Tests.cs
@@ -34,6 +34,7 @@ using Crypter.Crypto.Common.StreamEncryption;
 using Crypter.Test.Integration_Tests.Common;
 using Microsoft.AspNetCore.Mvc.Testing;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -87,9 +88,9 @@ namespace Crypter.Test.Integration_Tests.FileTransfer_Tests
          InsertKeyPairRequest insertKeyPairRequest = TestData.GetInsertKeyPairRequest();
          var insertKeyPairResponse = await _client.UserKey.InsertKeyPairAsync(insertKeyPairRequest);
 
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadFileTransferRequest uploadFileTransferRequest = new UploadFileTransferRequest(TestData.DefaultTransferFileName, TestData.DefaultTransferFileContentType, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var uploadFileTransferResponse = await _client.FileTransfer.UploadFileTransferAsync(TestData.DefaultUsername, uploadFileTransferRequest, encryptionStream, false);
+         var uploadFileTransferResponse = await _client.FileTransfer.UploadFileTransferAsync(TestData.DefaultUsername, uploadFileTransferRequest, encryptionStreamOpener, false);
 
          var response = await _client.FileTransfer.GetReceivedFilesAsync();
          List<UserReceivedFileDTO> result = response.SomeOrDefault(null);

--- a/Crypter.Test/Integration_Tests/FileTransfer_Tests/GetSentFileTransfers_Tests.cs
+++ b/Crypter.Test/Integration_Tests/FileTransfer_Tests/GetSentFileTransfers_Tests.cs
@@ -34,6 +34,7 @@ using Crypter.Crypto.Common.StreamEncryption;
 using Crypter.Test.Integration_Tests.Common;
 using Microsoft.AspNetCore.Mvc.Testing;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -84,9 +85,9 @@ namespace Crypter.Test.Integration_Tests.FileTransfer_Tests
             await _clientTokenRepository.StoreRefreshTokenAsync(loginResponse.RefreshToken, TokenType.Session);
          });
 
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadFileTransferRequest uploadFileRequest = new UploadFileTransferRequest(TestData.DefaultTransferFileName, TestData.DefaultTransferFileContentType, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var uploadFileResponse = await _client.FileTransfer.UploadFileTransferAsync(Maybe<string>.None, uploadFileRequest, encryptionStream, true);
+         var uploadFileResponse = await _client.FileTransfer.UploadFileTransferAsync(Maybe<string>.None, uploadFileRequest, encryptionStreamOpener, true);
 
          var response = await _client.FileTransfer.GetSentFilesAsync();
          List<UserSentFileDTO> result = response.SomeOrDefault(null);

--- a/Crypter.Test/Integration_Tests/FileTransfer_Tests/PreviewFileTransfer_Tests.cs
+++ b/Crypter.Test/Integration_Tests/FileTransfer_Tests/PreviewFileTransfer_Tests.cs
@@ -34,6 +34,7 @@ using Crypter.Crypto.Common.StreamEncryption;
 using Crypter.Test.Integration_Tests.Common;
 using Microsoft.AspNetCore.Mvc.Testing;
 using NUnit.Framework;
+using System;
 using System.Threading.Tasks;
 
 namespace Crypter.Test.Integration_Tests.FileTransfer_Tests
@@ -71,9 +72,9 @@ namespace Crypter.Test.Integration_Tests.FileTransfer_Tests
       [Test]
       public async Task Preview_Anonymous_File_Transfer_Works()
       {
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadFileTransferRequest uploadRequest = new UploadFileTransferRequest(TestData.DefaultTransferFileName, TestData.DefaultTransferFileContentType, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var uploadResult = await _client.FileTransfer.UploadFileTransferAsync(Maybe<string>.None, uploadRequest, encryptionStream, false);
+         var uploadResult = await _client.FileTransfer.UploadFileTransferAsync(Maybe<string>.None, uploadRequest, encryptionStreamOpener, false);
 
          string uploadId = uploadResult
             .Map(x => x.HashId)
@@ -130,9 +131,9 @@ namespace Crypter.Test.Integration_Tests.FileTransfer_Tests
             var registrationResult = await _client.UserAuthentication.RegisterAsync(registrationRequest);
          });
 
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadFileTransferRequest uploadRequest = new UploadFileTransferRequest(TestData.DefaultTransferFileName, TestData.DefaultTransferFileContentType, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var uploadResult = await _client.FileTransfer.UploadFileTransferAsync(recipientUsername, uploadRequest, encryptionStream, senderDefined);
+         var uploadResult = await _client.FileTransfer.UploadFileTransferAsync(recipientUsername, uploadRequest, encryptionStreamOpener, senderDefined);
 
          await recipientUsername.IfSomeAsync(async username =>
          {

--- a/Crypter.Test/Integration_Tests/MessageTransfer_Tests/DownloadMessageTransfer_Tests.cs
+++ b/Crypter.Test/Integration_Tests/MessageTransfer_Tests/DownloadMessageTransfer_Tests.cs
@@ -70,7 +70,7 @@ namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
       }
 
       [Test]
-      public async Task Preview_Anonymous_Message_Transfer_Works()
+      public async Task Download_Anonymous_Message_Transfer_Works()
       {
          (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadMessageTransferRequest request = new UploadMessageTransferRequest(TestData.DefaultTransferMessageSubject, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
@@ -84,12 +84,16 @@ namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
 
          Assert.True(uploadResult.IsRight);
          Assert.True(result.IsRight);
+         result.DoRight(x =>
+         {
+            Assert.DoesNotThrow(() => x.Stream.ReadByte());
+         });
       }
 
       [TestCase(true, false)]
       [TestCase(false, true)]
       [TestCase(true, true)]
-      public async Task Preview_User_Message_Transfer_Works(bool senderDefined, bool recipientDefined)
+      public async Task Download_User_Message_Transfer_Works(bool senderDefined, bool recipientDefined)
       {
          Maybe<string> senderUsername = senderDefined
             ? TestData.DefaultUsername
@@ -155,6 +159,10 @@ namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
 
          Assert.True(uploadResult.IsRight);
          Assert.True(result.IsRight);
+         result.DoRight(x =>
+         {
+            Assert.DoesNotThrow(() => x.Stream.ReadByte());
+         });
       }
    }
 }

--- a/Crypter.Test/Integration_Tests/MessageTransfer_Tests/DownloadMessageTransfer_Tests.cs
+++ b/Crypter.Test/Integration_Tests/MessageTransfer_Tests/DownloadMessageTransfer_Tests.cs
@@ -34,6 +34,7 @@ using Crypter.Crypto.Common.StreamEncryption;
 using Crypter.Test.Integration_Tests.Common;
 using Microsoft.AspNetCore.Mvc.Testing;
 using NUnit.Framework;
+using System;
 using System.Threading.Tasks;
 
 namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
@@ -71,9 +72,9 @@ namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
       [Test]
       public async Task Preview_Anonymous_Message_Transfer_Works()
       {
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadMessageTransferRequest request = new UploadMessageTransferRequest(TestData.DefaultTransferMessageSubject, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var uploadResult = await _client.MessageTransfer.UploadMessageTransferAsync(Maybe<string>.None, request, encryptionStream, false);
+         var uploadResult = await _client.MessageTransfer.UploadMessageTransferAsync(Maybe<string>.None, request, encryptionStreamOpener, false);
 
          string uploadId = uploadResult
             .Map(x => x.HashId)
@@ -130,9 +131,9 @@ namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
             var registrationResult = await _client.UserAuthentication.RegisterAsync(registrationRequest);
          });
 
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadMessageTransferRequest uploadRequest = new UploadMessageTransferRequest(TestData.DefaultTransferMessageSubject, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var uploadResult = await _client.MessageTransfer.UploadMessageTransferAsync(recipientUsername, uploadRequest, encryptionStream, senderDefined);
+         var uploadResult = await _client.MessageTransfer.UploadMessageTransferAsync(recipientUsername, uploadRequest, encryptionStreamOpener, senderDefined);
 
          await recipientUsername.IfSomeAsync(async username =>
          {

--- a/Crypter.Test/Integration_Tests/MessageTransfer_Tests/GetReceivedMessageTransfers_Tests.cs
+++ b/Crypter.Test/Integration_Tests/MessageTransfer_Tests/GetReceivedMessageTransfers_Tests.cs
@@ -34,6 +34,7 @@ using Crypter.Crypto.Common.StreamEncryption;
 using Crypter.Test.Integration_Tests.Common;
 using Microsoft.AspNetCore.Mvc.Testing;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -87,9 +88,9 @@ namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
          InsertKeyPairRequest insertKeyPairRequest = TestData.GetInsertKeyPairRequest();
          var insertKeyPairResponse = await _client.UserKey.InsertKeyPairAsync(insertKeyPairRequest);
 
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadMessageTransferRequest uploadMessageRequest = new UploadMessageTransferRequest(TestData.DefaultTransferMessageSubject, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var uploadMessageResponse = await _client.MessageTransfer.UploadMessageTransferAsync(TestData.DefaultUsername, uploadMessageRequest, encryptionStream, true);
+         var uploadMessageResponse = await _client.MessageTransfer.UploadMessageTransferAsync(TestData.DefaultUsername, uploadMessageRequest, encryptionStreamOpener, true);
 
          var response = await _client.MessageTransfer.GetReceivedMessagesAsync();
          List<UserReceivedMessageDTO> result = response.SomeOrDefault(null);

--- a/Crypter.Test/Integration_Tests/MessageTransfer_Tests/GetSentMessageTransfers_Tests.cs
+++ b/Crypter.Test/Integration_Tests/MessageTransfer_Tests/GetSentMessageTransfers_Tests.cs
@@ -34,6 +34,7 @@ using Crypter.Crypto.Common.StreamEncryption;
 using Crypter.Test.Integration_Tests.Common;
 using Microsoft.AspNetCore.Mvc.Testing;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -84,9 +85,9 @@ namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
             await _clientTokenRepository.StoreRefreshTokenAsync(loginResponse.RefreshToken, TokenType.Session);
          });
 
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadMessageTransferRequest uploadMessageRequest = new UploadMessageTransferRequest(TestData.DefaultTransferMessageSubject, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var uploadMessageResponse = await _client.MessageTransfer.UploadMessageTransferAsync(Maybe<string>.None, uploadMessageRequest, encryptionStream, true);
+         var uploadMessageResponse = await _client.MessageTransfer.UploadMessageTransferAsync(Maybe<string>.None, uploadMessageRequest, encryptionStreamOpener, true);
 
          var response = await _client.MessageTransfer.GetSentMessagesAsync();
          List<UserSentMessageDTO> result = response.SomeOrDefault(null);

--- a/Crypter.Test/Integration_Tests/MessageTransfer_Tests/PreviewMessageTransfer_Tests.cs
+++ b/Crypter.Test/Integration_Tests/MessageTransfer_Tests/PreviewMessageTransfer_Tests.cs
@@ -34,6 +34,7 @@ using Crypter.Crypto.Common.StreamEncryption;
 using Crypter.Test.Integration_Tests.Common;
 using Microsoft.AspNetCore.Mvc.Testing;
 using NUnit.Framework;
+using System;
 using System.Threading.Tasks;
 
 namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
@@ -71,9 +72,9 @@ namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
       [Test]
       public async Task Preview_Anonymous_Message_Transfer_Works()
       {
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadMessageTransferRequest request = new UploadMessageTransferRequest(TestData.DefaultTransferMessageSubject, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var uploadResult = await _client.MessageTransfer.UploadMessageTransferAsync(Maybe<string>.None, request, encryptionStream, false);
+         var uploadResult = await _client.MessageTransfer.UploadMessageTransferAsync(Maybe<string>.None, request, encryptionStreamOpener, false);
 
          string uploadId = uploadResult
             .Map(x => x.HashId)
@@ -130,9 +131,9 @@ namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
             var registrationResult = await _client.UserAuthentication.RegisterAsync(registrationRequest);
          });
 
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadMessageTransferRequest uploadRequest = new UploadMessageTransferRequest(TestData.DefaultTransferMessageSubject, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var uploadResult = await _client.MessageTransfer.UploadMessageTransferAsync(recipientUsername, uploadRequest, encryptionStream, senderDefined);
+         var uploadResult = await _client.MessageTransfer.UploadMessageTransferAsync(recipientUsername, uploadRequest, encryptionStreamOpener, senderDefined);
 
          await recipientUsername.IfSomeAsync(async username =>
          {

--- a/Crypter.Test/Integration_Tests/MessageTransfer_Tests/UploadMessageTransfer_Tests.cs
+++ b/Crypter.Test/Integration_Tests/MessageTransfer_Tests/UploadMessageTransfer_Tests.cs
@@ -72,9 +72,9 @@ namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
       [Test]
       public async Task Upload_Anonymous_Message_Transfer_Works()
       {
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadMessageTransferRequest request = new UploadMessageTransferRequest(TestData.DefaultTransferMessageSubject, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var result = await _client.MessageTransfer.UploadMessageTransferAsync(Maybe<string>.None, request, encryptionStream, false);
+         var result = await _client.MessageTransfer.UploadMessageTransferAsync(Maybe<string>.None, request, encryptionStreamOpener, false);
 
          Assert.True(result.IsRight);
       }
@@ -124,9 +124,9 @@ namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
             var registrationResult = await _client.UserAuthentication.RegisterAsync(registrationRequest);
          });
 
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadMessageTransferRequest request = new UploadMessageTransferRequest(TestData.DefaultTransferMessageSubject, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var result = await _client.MessageTransfer.UploadMessageTransferAsync(recipientUsername, request, encryptionStream, senderDefined);
+         var result = await _client.MessageTransfer.UploadMessageTransferAsync(recipientUsername, request, encryptionStreamOpener, senderDefined);
 
          Assert.True(result.IsRight);
       }
@@ -134,9 +134,9 @@ namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
       [Test]
       public async Task Upload_User_Message_Transfer_Fails_When_Recipient_Does_Not_Exist()
       {
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadMessageTransferRequest request = new UploadMessageTransferRequest(TestData.DefaultTransferMessageSubject, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-         var result = await _client.MessageTransfer.UploadMessageTransferAsync("John Smith", request, encryptionStream, false);
+         var result = await _client.MessageTransfer.UploadMessageTransferAsync("John Smith", request, encryptionStreamOpener, false);
 
          Assert.True(result.IsLeft);
       }
@@ -144,10 +144,38 @@ namespace Crypter.Test.Integration_Tests.MessageTransfer_Tests
       [Test]
       public void Upload_Authenticated_Message_Transfer_Throws_When_Not_Authenticated()
       {
-         (EncryptionStream encryptionStream, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
          UploadMessageTransferRequest request = new UploadMessageTransferRequest(TestData.DefaultTransferMessageSubject, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
 
-         Assert.ThrowsAsync<InvalidOperationException>(async () => await _client.MessageTransfer.UploadMessageTransferAsync(Maybe<string>.None, request, encryptionStream, true));
+         Assert.ThrowsAsync<InvalidOperationException>(async () => await _client.MessageTransfer.UploadMessageTransferAsync(Maybe<string>.None, request, encryptionStreamOpener, true));
+      }
+
+      [Test]
+      public async Task Upload_User_Message_Transfer_Works_After_Refresh_Occurs()
+      {
+         const string senderUsername = TestData.DefaultUsername;
+         const string senderPassword = TestData.DefaultPassword;
+
+         RegistrationRequest registrationRequest = TestData.GetRegistrationRequest(senderUsername, senderPassword);
+         var registrationResult = await _client.UserAuthentication.RegisterAsync(registrationRequest);
+
+         LoginRequest loginRequest = TestData.GetLoginRequest(senderUsername, senderPassword, TokenType.Session);
+         var loginResult = await _client.UserAuthentication.LoginAsync(loginRequest);
+
+         await loginResult.DoRightAsync(async loginResponse =>
+         {
+            await _clientTokenRepository.StoreAuthenticationTokenAsync("bogus auth token");
+            await _clientTokenRepository.StoreRefreshTokenAsync(loginResponse.RefreshToken, TokenType.Session);
+         });
+
+         Assert.True(registrationResult.IsRight);
+         Assert.True(loginResult.IsRight);
+
+         (Func<EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
+         UploadMessageTransferRequest request = new UploadMessageTransferRequest(TestData.DefaultTransferMessageSubject, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce, keyExchangeProof, TestData.DefaultTransferLifetimeHours);
+         var result = await _client.MessageTransfer.UploadMessageTransferAsync(Maybe<string>.None, request, encryptionStreamOpener, true);
+
+         Assert.True(result.IsRight);
       }
    }
 }

--- a/Crypter.Web/Shared/Transfer/UploadFileTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/UploadFileTransfer.razor.cs
@@ -98,10 +98,10 @@ namespace Crypter.Web.Shared.Transfer
 
          await SetProgressMessage("Encrypting file");
 
-         Stream fileStreamFactory()
+         Stream fileStreamOpener()
             => SelectedFile.OpenReadStream(SelectedFile.Size);
 
-         UploadFileHandler fileUploader = TransferHandlerFactory.CreateUploadFileHandler(fileStreamFactory, SelectedFile.Name, SelectedFile.Size, SelectedFile.ContentType, ExpirationHours);
+         UploadFileHandler fileUploader = TransferHandlerFactory.CreateUploadFileHandler(fileStreamOpener, SelectedFile.Name, SelectedFile.Size, SelectedFile.ContentType, ExpirationHours);
 
          SetHandlerUserInfo(fileUploader);
          var uploadResponse = await fileUploader.UploadAsync();

--- a/Crypter.Web/Shared/Transfer/UploadFileTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/UploadFileTransfer.razor.cs
@@ -97,8 +97,11 @@ namespace Crypter.Web.Shared.Transfer
          ErrorMessage = string.Empty;
 
          await SetProgressMessage("Encrypting file");
-         using Stream fileStream = SelectedFile.OpenReadStream(SelectedFile.Size);
-         using UploadFileHandler fileUploader = TransferHandlerFactory.CreateUploadFileHandler(fileStream, SelectedFile.Name, SelectedFile.Size, SelectedFile.ContentType, ExpirationHours);
+
+         Stream fileStreamFactory()
+            => SelectedFile.OpenReadStream(SelectedFile.Size);
+
+         UploadFileHandler fileUploader = TransferHandlerFactory.CreateUploadFileHandler(fileStreamFactory, SelectedFile.Name, SelectedFile.Size, SelectedFile.ContentType, ExpirationHours);
 
          SetHandlerUserInfo(fileUploader);
          var uploadResponse = await fileUploader.UploadAsync();

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -14,9 +14,9 @@ services:
     ports:
       - ${POSTGRES_BIND_IP-[0.0.0.0]}:${POSTGRES_BIND_PORT-5432}:5432
     environment:
-      POSTGRES_PASSWORD: ${POSTGRES_SUPERUSER_PASSWORD-dev}
-      POSTGRES_C_PASSWORD: ${POSTGRES_USER_PASSWORD:-dev}
-      POSTGRES_HF_PASSWORD: ${POSTGRES_HANGFIRE_USER_PASSWORD:-dev}
+      POSTGRES_PASSWORD: ${POSTGRES_SUPERUSER_PASSWORD-DEFAULT_PASSWORD}
+      POSTGRES_C_PASSWORD: ${POSTGRES_USER_PASSWORD:-DEFAULT_PASSWORD}
+      POSTGRES_HF_PASSWORD: ${POSTGRES_HANGFIRE_USER_PASSWORD:-DEFAULT_PASSWORD}
     volumes:
       - ./Containers/PostgreSQL/data:/var/lib/postgresql/data
       - ./Containers/PostgreSQL/postgres-init-files:/docker-entrypoint-initdb.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
       ASPNETCORE_ENVIRONMENT: ${ASPNETCORE_ENVIRONMENT-Production}
       ASPNETCORE_URLS: http://0.0.0.0:80
       ASPNETCORE_TransferStorageSettings__Location: /mnt/storage
-      CUSTOMCONNSTR_DefaultConnection: host=${POSTGRES_HOST:-db};database=crypter;user id=crypter_user;pwd=${POSTGRES_USER_PASSWORD:-dev};
-      CUSTOMCONNSTR_HangfireConnection: host=${POSTGRES_HANGFIRE_HOST:-db};database=crypter_hangfire;user id=crypter_hangfire_user;pwd=${POSTGRES_HANGFIRE_USER_PASSWORD:-dev};
+      CUSTOMCONNSTR_DefaultConnection: host=${POSTGRES_HOST:-db};database=crypter;user id=crypter_user;pwd=${POSTGRES_USER_PASSWORD:-DEFAULT_PASSWORD};
+      CUSTOMCONNSTR_HangfireConnection: host=${POSTGRES_HANGFIRE_HOST:-db};database=crypter_hangfire;user id=crypter_hangfire_user;pwd=${POSTGRES_HANGFIRE_USER_PASSWORD:-DEFAULT_PASSWORD};
     volumes:
       - ${API_STORAGE_PATH}:/mnt/storage
       - ${API_SETTINGS_FILE}:/app/appsettings.json


### PR DESCRIPTION
Resolve #527 

Discrete instances of HttpRequestMessage were being sent through the authenticated http client.  This works fine, until the http client receives a 401, performs a token refresh, and attempts to resend the same discrete request message.

This PR wraps those instances of HttpRequestMessage in a Func, meaning the http client can create a new request message with the original parameters.

I also wrapped the StreamContent's content in a Func for the same reason.  The code should not re-send the same stream again.  It needs to send a brand new stream.

I also added some more explicit object disposal.