### PR TITLE
Handle possible empty email address when changing contact info

### DIFF
--- a/Crypter.Common.Client/Events/UserContactInfoChangedEventArgs.cs
+++ b/Crypter.Common.Client/Events/UserContactInfoChangedEventArgs.cs
@@ -24,6 +24,7 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
+using Crypter.Common.Monads;
 using Crypter.Common.Primitives;
 using System;
 
@@ -31,10 +32,10 @@ namespace Crypter.Common.Client.Events
 {
    public class UserContactInfoChangedEventArgs : EventArgs
    {
-      public EmailAddress EmailAddress { get; init; }
+      public Maybe<EmailAddress> EmailAddress { get; init; }
       public bool EmailAddressVerified { get; init; }
 
-      public UserContactInfoChangedEventArgs(EmailAddress emailAddress, bool emailAddressVerified)
+      public UserContactInfoChangedEventArgs(Maybe<EmailAddress> emailAddress, bool emailAddressVerified)
       {
          EmailAddress = emailAddress;
          EmailAddressVerified = emailAddressVerified;

--- a/Crypter.Common.Client/Services/UserSettings/UserContactInfoSettingsService.cs
+++ b/Crypter.Common.Client/Services/UserSettings/UserContactInfoSettingsService.cs
@@ -86,7 +86,10 @@ namespace Crypter.Common.Client.Services.UserSettings
 
                response.DoRight(updatedContactInfoSettings =>
                {
-                  HandleUserContactInfoChangedEvent(EmailAddress.From(updatedContactInfoSettings.EmailAddress), updatedContactInfoSettings.EmailAddressVerified);
+                  Maybe<EmailAddress> newEmailAddress = EmailAddress.TryFrom(updatedContactInfoSettings.EmailAddress, out EmailAddress newValidEmailAddress)
+                     ? newValidEmailAddress
+                     : Maybe<EmailAddress>.None;
+                  HandleUserContactInfoChangedEvent(newEmailAddress, updatedContactInfoSettings.EmailAddressVerified);
                });
 
                return response;
@@ -99,7 +102,7 @@ namespace Crypter.Common.Client.Services.UserSettings
          remove => _userContactInfoChangedEventHandler = (EventHandler<UserContactInfoChangedEventArgs>)Delegate.Remove(_userContactInfoChangedEventHandler, value);
       }
 
-      private void HandleUserContactInfoChangedEvent(EmailAddress emailAddress, bool emailAddressVerified) =>
+      private void HandleUserContactInfoChangedEvent(Maybe<EmailAddress> emailAddress, bool emailAddressVerified) =>
          _userContactInfoChangedEventHandler?.Invoke(this, new UserContactInfoChangedEventArgs(emailAddress, emailAddressVerified));
 
       private void Recycle(object sender, EventArgs _)


### PR DESCRIPTION
`UserContactInfoChangedEventArgs` should not assume the user has set a valid email address.  It's possible the user actually cleared their email address from their profile.