### PR TITLE
Rename Finalize methods baesd on Rider feedback

### DIFF
--- a/Crypter.Crypto.Common/KeyExchange/AbstractKeyExchange.cs
+++ b/Crypter.Crypto.Common/KeyExchange/AbstractKeyExchange.cs
@@ -76,14 +76,14 @@ namespace Crypter.Crypto.Common.KeyExchange
          encryptionKeyHasher.Update(sharedKey);
          encryptionKeyHasher.Update(publicKey);
          encryptionKeyHasher.Update(generatedPublicKey);
-         byte[] encryptionKey = encryptionKeyHasher.Finalize();
+         byte[] encryptionKey = encryptionKeyHasher.Complete();
 
          IStreamGenericHash decryptionKeyHasher = _streamGenericHashFactory.NewGenericHashStream(keySize, nonce);
          decryptionKeyHasher.Update(_kxContext);
          decryptionKeyHasher.Update(sharedKey);
          decryptionKeyHasher.Update(generatedPublicKey);
          decryptionKeyHasher.Update(publicKey);
-         byte[] decryptionKey = decryptionKeyHasher.Finalize();
+         byte[] decryptionKey = decryptionKeyHasher.Complete();
 
          byte[] proof = GenerateProof(encryptionKey, decryptionKey, nonce);
          return (encryptionKey, decryptionKey, proof);
@@ -114,7 +114,7 @@ namespace Crypter.Crypto.Common.KeyExchange
          IStreamGenericHash digestor = _streamGenericHashFactory.NewGenericHashStream(ProofSize, nonce);
          digestor.Update(firstKey);
          digestor.Update(secondKey);
-         return digestor.Finalize();
+         return digestor.Complete();
       }
    }
 }

--- a/Crypter.Crypto.Common/StreamGenericHash/IStreamGenericHash.cs
+++ b/Crypter.Crypto.Common/StreamGenericHash/IStreamGenericHash.cs
@@ -31,6 +31,6 @@ namespace Crypter.Crypto.Common.StreamGenericHash
    public interface IStreamGenericHash
    {
       void Update(ReadOnlySpan<byte> data);
-      byte[] Finalize();
+      byte[] Complete();
    }
 }

--- a/Crypter.Crypto.Providers.Browser/Wrappers/StreamGenericHash.cs
+++ b/Crypter.Crypto.Providers.Browser/Wrappers/StreamGenericHash.cs
@@ -47,7 +47,7 @@ namespace Crypter.Crypto.Providers.Browser.Wrappers
          _stateAddress = BlazorSodium.Sodium.GenericHash.Crypto_GenericHash_Init(_hashLength, keyBytes);
       }
 
-      public byte[] Finalize()
+      public byte[] Complete()
       {
          return BlazorSodium.Sodium.GenericHash.Crypto_GenericHash_Final(_stateAddress, _hashLength);
       }

--- a/Crypter.Crypto.Providers.Default/Wrappers/StreamGenericHash.cs
+++ b/Crypter.Crypto.Providers.Default/Wrappers/StreamGenericHash.cs
@@ -43,7 +43,7 @@ namespace Crypter.Crypto.Providers.Default.Wrappers
          _state = new IncrementalBLAKE2b(checked((int)hashLength), key);
       }
 
-      public byte[] Finalize()
+      public byte[] Complete()
       {
          byte[] buffer = new byte[_hashLength];
          _state.Finalize(buffer);


### PR DESCRIPTION
Rider was warning against using a method named "Finalize".  Rename these methods.