### PR TITLE
Create "prod" and "dev" GHCR workflows

### DIFF
--- a/.github/workflows/build-and-push-api-dev.yml
+++ b/.github/workflows/build-and-push-api-dev.yml
@@ -1,0 +1,14 @@
+﻿name: Push a development image of Crypter.API to GitHub Container Registry
+
+on:
+  release:
+    types:
+      - published
+  
+  workflow_dispatch:
+
+jobs:
+  build-and-push-api-to-production:
+    uses: crypter-file-transfer/crypter/.github/workflows/build-and-push.api.yml@2b75721acbd0d9ee7aa235a286c094571d06aa73
+    with:
+      environment-name: development

--- a/.github/workflows/build-and-push-api-dev.yml
+++ b/.github/workflows/build-and-push-api-dev.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-push-api-to-production:
-    uses: crypter-file-transfer/crypter/.github/workflows/build-and-push.api.yml@2b75721acbd0d9ee7aa235a286c094571d06aa73
+  build-and-push-api-to-development:
+    uses: crypter-file-transfer/crypter/.github/workflows/build-and-push-api.yml@2b75721acbd0d9ee7aa235a286c094571d06aa73
     with:
       environment-name: development

--- a/.github/workflows/build-and-push-api-prod.yml
+++ b/.github/workflows/build-and-push-api-prod.yml
@@ -1,0 +1,14 @@
+﻿name: Push a production image of Crypter.API to GitHub Container Registry
+
+on: 
+  release:
+    types:
+      - published
+        
+  workflow_dispatch:
+    
+jobs:
+  build-and-push-api-to-production:
+    uses: crypter-file-transfer/crypter/.github/workflows/build-and-push.api.yml@2b75721acbd0d9ee7aa235a286c094571d06aa73
+    with:
+      environment-name: production

--- a/.github/workflows/build-and-push-api-prod.yml
+++ b/.github/workflows/build-and-push-api-prod.yml
@@ -9,6 +9,6 @@ on:
     
 jobs:
   build-and-push-api-to-production:
-    uses: crypter-file-transfer/crypter/.github/workflows/build-and-push.api.yml@2b75721acbd0d9ee7aa235a286c094571d06aa73
+    uses: crypter-file-transfer/crypter/.github/workflows/build-and-push-api.yml@2b75721acbd0d9ee7aa235a286c094571d06aa73
     with:
       environment-name: production

--- a/.github/workflows/build-and-push-api.yml
+++ b/.github/workflows/build-and-push-api.yml
@@ -1,14 +1,11 @@
-name: Release API to GitHub Container Registry
+name: Reusable workflow to push and image of Crypter.API to a GitHub Container Registry
 
 on:
-  release:
-    types:
-    - published
-
-  workflow_dispatch:
-
-env:
-  registry: ghcr.io/${{ github.repository_owner }}
+  workflow_call:
+    inputs:
+      environment-name:
+        required: true
+        type: string
 
 jobs:
   build-and-push-api:
@@ -18,6 +15,7 @@ jobs:
       packages: write
     env:
       project_root: Crypter.API/
+    environment: ${{ inputs.environment-name }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-and-push-api.yml
+++ b/.github/workflows/build-and-push-api.yml
@@ -18,7 +18,6 @@ jobs:
       packages: write
     env:
       project_root: Crypter.API/
-      image_name: crypter_api
 
     steps:
       - name: Checkout repository
@@ -38,7 +37,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.registry }}/${{ env.image_name }}
+          images: ${{ env.registry }}/${{ env.API_IMAGE_NAME }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4

--- a/.github/workflows/build-and-push-web-dev.yml
+++ b/.github/workflows/build-and-push-web-dev.yml
@@ -1,0 +1,14 @@
+﻿name: Push a development image of Crypter.Web to GitHub Container Registry
+
+on:
+  release:
+    types:
+      - published
+  
+  workflow_dispatch:
+
+jobs:
+  build-and-push-web-to-development:
+    uses: crypter-file-transfer/crypter/.github/workflows/build-and-push-web.yml@bfc392b2e3522630eede8fecd019a00e032839aa
+    with:
+      environment-name: development

--- a/.github/workflows/build-and-push-web-prod.yml
+++ b/.github/workflows/build-and-push-web-prod.yml
@@ -1,0 +1,14 @@
+﻿name: Push a production image of Crypter.Web to GitHub Container Registry
+
+on:
+  release:
+    types:
+      - published
+  
+  workflow_dispatch:
+
+jobs:
+  build-and-push-web-to-production:
+    uses: crypter-file-transfer/crypter/.github/workflows/build-and-push-web.yml@bfc392b2e3522630eede8fecd019a00e032839aa
+    with:
+      environment-name: production

--- a/.github/workflows/build-and-push-web.yml
+++ b/.github/workflows/build-and-push-web.yml
@@ -1,11 +1,11 @@
-name: Release web application to GitHub Container Registry
+name: Reusable workflow to push an image of Crypter.Web to a GitHub Container Registry
 
 on:
-  release:
-    types:
-    - published
-
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      environment-name:
+        required: true
+        type: string
 
 env:
   registry: ghcr.io/${{ github.repository_owner }}
@@ -18,6 +18,7 @@ jobs:
       packages: write
     env:
       project_root: Crypter.Web/
+    environment: ${{ inputs.environment-name }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-and-push-web.yml
+++ b/.github/workflows/build-and-push-web.yml
@@ -18,7 +18,6 @@ jobs:
       packages: write
     env:
       project_root: Crypter.Web/
-      image_name: crypter_web
 
     steps:
       - name: Checkout repository
@@ -43,7 +42,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.registry }}/${{ env.image_name }}
+          images: ${{ env.registry }}/${{ env.WEB_IMAGE_NAME }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4


### PR DESCRIPTION
Split the existing GHCR workflows into separate "prod" and "dev" workflows.

The intent is to tag images differently based on the environment.  Production images would continue to use the same tags as today.  Development images would be tagged "foo-dev".