### PR TITLE
Bind the TransferSettings input to a string to resolve a razor error

### DIFF
--- a/Crypter.Web/Shared/Transfer/TransferSettings.razor
+++ b/Crypter.Web/Shared/Transfer/TransferSettings.razor
@@ -24,12 +24,10 @@
    * Contact the current copyright holder to discuss commercial license options.
  *@
 
-@inherits TransferSettingsBase
-
 <div class="transfer-settings text-start">
    <div class="mb-3">
       <label for="expirationHours" class="form-label">Expiration hours</label>
-      <input type="number" @bind:get="ExpirationHours" @bind:set="OnExpirationHoursChanged" min="@MinExpirationHours" max="@MaxExpirationHours" class="form-control w-auto" id="expirationHours" placeholder="Hours">
+      <input type="number" @bind:get="_expirationInput" @bind:set="OnExpirationHoursChanged" min="@MinExpirationHours" max="@MaxExpirationHours" class="form-control w-auto" id="expirationHours" placeholder="Hours">
       <div id="expirationHelp" class="form-text">The number of hours before an upload is automatically deleted.</div>
    </div>
 </div>

--- a/Crypter.Web/Shared/Transfer/TransferSettings.razor.cs
+++ b/Crypter.Web/Shared/Transfer/TransferSettings.razor.cs
@@ -27,53 +27,64 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
 
-namespace Crypter.Web.Shared.Transfer
+namespace Crypter.Web.Shared.Transfer;
+
+public partial class TransferSettings
 {
-   public partial class TransferSettingsBase : ComponentBase
+   private const int MinExpirationHours = 1;
+   private const int MaxExpirationHours = 24;
+   private const int DefaultExpirationHours = 24;
+
+   private string _expirationInput;
+   
+   [Parameter]
+   public int ExpirationHours { get; set; }
+
+   [Parameter]
+   public EventCallback<int> ExpirationHoursChanged { get; set; }
+
+   protected override Task OnParametersSetAsync()
    {
-      protected const int MinExpirationHours = 1;
-      protected const int MaxExpirationHours = 24;
-      protected const int DefaultExpirationHours = 24;
-
-      [Parameter]
-      public int ExpirationHours { get; set; }
-
-      [Parameter]
-      public EventCallback<int> ExpirationHoursChanged { get; set; }
-
-      protected override Task OnParametersSetAsync()
+      if (ExpirationHours > MaxExpirationHours)
       {
-         if (ExpirationHours > MaxExpirationHours)
-         {
-            return ExpirationHoursChanged.InvokeAsync(MaxExpirationHours);
-         }
+         _expirationInput = MaxExpirationHours.ToString();
+         return ExpirationHoursChanged.InvokeAsync(MaxExpirationHours);
+      }
 
-         if (ExpirationHours < MinExpirationHours)
-         {
-            return ExpirationHoursChanged.InvokeAsync(DefaultExpirationHours);
-         }
+      if (ExpirationHours < MinExpirationHours)
+      {
+         _expirationInput = MinExpirationHours.ToString();
+         return ExpirationHoursChanged.InvokeAsync(DefaultExpirationHours);
+      }
 
+      _expirationInput = ExpirationHours.ToString();
+      return Task.CompletedTask;
+   }
+
+   private Task OnExpirationHoursChanged(string value)
+   {
+      if (!int.TryParse(value, out int parsedValue))
+      {
+         ExpirationHours = DefaultExpirationHours;
+         _expirationInput = DefaultExpirationHours.ToString();
+         return ExpirationHoursChanged.InvokeAsync(DefaultExpirationHours);
+      }
+
+      if (ExpirationHours == parsedValue)
+      {
          return Task.CompletedTask;
       }
-
-      protected Task OnExpirationHoursChanged(int value)
+      
+      if (parsedValue > MaxExpirationHours)
       {
-         if (ExpirationHours == value)
-         {
-            return Task.CompletedTask;
-         }
-
-         if (value > MaxExpirationHours)
-         {
-            return ExpirationHoursChanged.InvokeAsync(MaxExpirationHours);
-         }
-         
-         if (value < MinExpirationHours)
-         {
-            return ExpirationHoursChanged.InvokeAsync(MinExpirationHours);
-         }
-
-         return ExpirationHoursChanged.InvokeAsync(value);
+         return ExpirationHoursChanged.InvokeAsync(MaxExpirationHours);
       }
+      
+      if (parsedValue < MinExpirationHours)
+      {
+         return ExpirationHoursChanged.InvokeAsync(MinExpirationHours);
+      }
+
+      return ExpirationHoursChanged.InvokeAsync(parsedValue);
    }
 }


### PR DESCRIPTION
`TransferSettings.razor` has been reporting an error for a long time.  `ExpirationHours` is an integer, yet `@bind:get="ExpirationHours"` expects a string.

This PR uses a `string` backing field to resolve the razor error and cleans up the class definition (use partials instead of inheritance).