### PR TITLE
Add a configuration to enable automatic database migrations on API startup

### DIFF
--- a/Crypter.API/Program.cs
+++ b/Crypter.API/Program.cs
@@ -34,12 +34,10 @@ using Crypter.Core;
 using Crypter.Core.Identity;
 using Crypter.Core.Models;
 using Crypter.Core.Settings;
-using Crypter.DataAccess;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -112,10 +110,6 @@ if (app.Environment.IsDevelopment())
 
     app.UseSwagger();
     app.UseSwaggerUI();
-
-    using IServiceScope serviceScope = app.Services.GetService<IServiceScopeFactory>().CreateScope();
-    await using DataContext context = serviceScope.ServiceProvider.GetRequiredService<DataContext>();
-    await context.Database.MigrateAsync();
 }
 else
 {
@@ -128,6 +122,11 @@ else
     });
 }
 
+DatabaseSettings dbSettings = app.Configuration
+    .GetSection("DatabaseSettings")
+    .Get<DatabaseSettings>();
+await app.ApplyCrypterCoreAsync(dbSettings);
+
 app.UseHttpsRedirection();
 app.UseRouting();
 app.UseAuthentication();
@@ -135,4 +134,4 @@ app.UseAuthorization();
 app.UseMiddleware<ExceptionHandlerMiddleware>();
 app.MapControllers();
 
-app.Run();
+await app.RunAsync();

--- a/Crypter.API/Program.cs
+++ b/Crypter.API/Program.cs
@@ -39,6 +39,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -113,8 +114,8 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 
     using IServiceScope serviceScope = app.Services.GetService<IServiceScopeFactory>().CreateScope();
-    using DataContext context = serviceScope.ServiceProvider.GetRequiredService<DataContext>();
-    context.Database.EnsureCreated();
+    await using DataContext context = serviceScope.ServiceProvider.GetRequiredService<DataContext>();
+    await context.Database.MigrateAsync();
 }
 else
 {

--- a/Crypter.API/appsettings.json
+++ b/Crypter.API/appsettings.json
@@ -4,6 +4,9 @@
       "DefaultConnection": "host=127.0.0.1;database=crypter;user id=crypter_user;pwd=DEFAULT_PASSWORD;",
       "HangfireConnection": "host=127.0.0.1;database=crypter_hangfire;user id=crypter_hangfire_user;pwd=DEFAULT_PASSWORD;"
    },
+   "DatabaseSettings": {
+      "MigrateOnStartup": true
+   },
    "EmailSettings": {
       "Enabled": false,
       "From": "no-reply@crypter.dev",

--- a/Crypter.Core/Settings/DatabaseSettings.cs
+++ b/Crypter.Core/Settings/DatabaseSettings.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * Copyright (C) 2023 Crypter File Transfer
+ *
+ * This file is part of the Crypter file transfer project.
+ *
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ *
+ * Contact the current copyright holder to discuss commercial license options.
+ */
+
+namespace Crypter.Core.Settings;
+
+public class DatabaseSettings
+{
+    public bool MigrateOnStartup { get; set; }
+}

--- a/Crypter.Test/AssemblySetup.cs
+++ b/Crypter.Test/AssemblySetup.cs
@@ -36,6 +36,8 @@ using Crypter.Common.Client.Repositories;
 using Crypter.DataAccess;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
@@ -89,7 +91,7 @@ internal class AssemblySetup
     }
 
     internal static async Task<WebApplicationFactory<Program>> CreateWebApplicationFactoryAsync(
-        bool ensureDatabaseCreated = true, IServiceCollection overrides = null)
+        bool ensureDatabaseMigrated = true, IServiceCollection overrides = null)
     {
         WebApplicationFactory<Program> factory = new WebApplicationFactory<Program>()
             .WithWebHostBuilder(builder =>
@@ -115,11 +117,11 @@ internal class AssemblySetup
                 builder.UseSetting("TransferStorageSettings:Location", FileStorageLocation);
             });
 
-        if (ensureDatabaseCreated)
+        if (ensureDatabaseMigrated)
         {
             using IServiceScope scope = factory.Services.CreateScope();
             await using DataContext dataContext = scope.ServiceProvider.GetRequiredService<DataContext>();
-            await dataContext.Database.EnsureCreatedAsync();
+            await dataContext.Database.MigrateAsync();
         }
 
         return factory;
@@ -154,7 +156,8 @@ internal class AssemblySetup
             WithReseed = true,
             TablesToIgnore = new Table[]
             {
-                "schema"
+                "schema",
+                HistoryRepository.DefaultTableName
             }
         };
 

--- a/Volumes/API/appsettings.json
+++ b/Volumes/API/appsettings.json
@@ -1,5 +1,8 @@
 {
    "AllowedHosts": "*",
+   "DatabaseSettings": {
+      "MigrateOnStartup": true
+   },
    "EmailSettings": {
       "Enabled": false,
       "From": "no-reply@crypter.dev",

--- a/Volumes/PostgreSQL/postgres-init-files/init.sh
+++ b/Volumes/PostgreSQL/postgres-init-files/init.sh
@@ -11,6 +11,11 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
    REVOKE CONNECT ON DATABASE crypter_hangfire FROM PUBLIC;
 EOSQL
 
+# Create the "citext" extension on the "crypter" database
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "crypter" <<-EOSQL
+  CREATE EXTENSION IF NOT EXISTS citext;
+EOSQL
+
 # Create crypter_user
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "crypter" <<-EOSQL
    CREATE USER crypter_user WITH PASSWORD '$POSTGRES_C_PASSWORD';


### PR DESCRIPTION
This PR adds an option to the API configuration that controls whether the API will perform database migrations on startup.

Previously on startup, the API would have created the database if the database did not exist, but only when the ASPNETCORE_ENVIRONMENT was set to "Development".  The drawbacks here are:

1. You would only get the benefit of this feature if you were willing to run the API with all the other "Development" capabilities.
2. The database would not be created in a manner to support future schema changes.

Both these drawbacks are addressed by these changes.