### PR TITLE
Move several "key" queries to Mediatr

### DIFF
--- a/Crypter.Common.Client/Interfaces/Services/IUserRecoveryService.cs
+++ b/Crypter.Common.Client/Interfaces/Services/IUserRecoveryService.cs
@@ -48,11 +48,9 @@ public interface IUserRecoveryService
     /// Derivce a recovery key from the provided parameters.
     /// </summary>
     /// <param name="masterKey"></param>
-    /// <param name="username"></param>
     /// <param name="versionedPassword">A hashed password.</param>
     /// <returns></returns>
-    Task<Maybe<RecoveryKey>> DeriveRecoveryKeyAsync(byte[] masterKey, Username username,
-        VersionedPassword versionedPassword);
+    Task<Maybe<RecoveryKey>> DeriveRecoveryKeyAsync(byte[] masterKey, VersionedPassword versionedPassword);
 
     Task RequestRecoveryEmailAsync(EmailAddress emailAddress);
 

--- a/Crypter.Common.Client/Services/UserRecoveryService.cs
+++ b/Crypter.Common.Client/Services/UserRecoveryService.cs
@@ -100,14 +100,13 @@ public class UserRecoveryService : IUserRecoveryService
     {
         return _userPasswordService
             .DeriveUserAuthenticationPasswordAsync(username, password, _userPasswordService.CurrentPasswordVersion)
-            .BindAsync(versionedPassword => DeriveRecoveryKeyAsync(masterKey, username, versionedPassword));
+            .BindAsync(versionedPassword => DeriveRecoveryKeyAsync(masterKey, versionedPassword));
     }
 
-    public Task<Maybe<RecoveryKey>> DeriveRecoveryKeyAsync(byte[] masterKey, Username username,
-        VersionedPassword versionedPassword)
+    public Task<Maybe<RecoveryKey>> DeriveRecoveryKeyAsync(byte[] masterKey, VersionedPassword versionedPassword)
     {
         GetMasterKeyRecoveryProofRequest request =
-            new GetMasterKeyRecoveryProofRequest(username, versionedPassword.Password);
+            new GetMasterKeyRecoveryProofRequest(versionedPassword.Password);
         return _crypterApiClient.UserKey.GetMasterKeyRecoveryProofAsync(request)
             .ToMaybeTask()
             .MapAsync(x => new RecoveryKey(masterKey, x.Proof));

--- a/Crypter.Common/Contracts/Features/Keys/GetMasterKeyRecoveryProof/GetMasterKeyRecoveryProofRequest.cs
+++ b/Crypter.Common/Contracts/Features/Keys/GetMasterKeyRecoveryProof/GetMasterKeyRecoveryProofRequest.cs
@@ -25,25 +25,16 @@
  */
 
 using System.Text.Json.Serialization;
-using Crypter.Common.Primitives;
 
 namespace Crypter.Common.Contracts.Features.Keys;
 
 public class GetMasterKeyRecoveryProofRequest
 {
-    public string Username { get; init; }
-    public byte[] Password { get; init; }
+    public byte[] AuthenticationPassword { get; init; }
 
     [JsonConstructor]
-    public GetMasterKeyRecoveryProofRequest(string username, byte[] password)
+    public GetMasterKeyRecoveryProofRequest(byte[] authenticationPassword)
     {
-        Username = username;
-        Password = password;
-    }
-
-    public GetMasterKeyRecoveryProofRequest(Username username, byte[] password)
-    {
-        Username = username.Value;
-        Password = password;
+        AuthenticationPassword = authenticationPassword;
     }
 }

--- a/Crypter.Common/Contracts/Features/UserAuthentication/PasswordChallenge/PasswordChallengeRequest.cs
+++ b/Crypter.Common/Contracts/Features/UserAuthentication/PasswordChallenge/PasswordChallengeRequest.cs
@@ -28,10 +28,10 @@ namespace Crypter.Common.Contracts.Features.UserAuthentication;
 
 public class PasswordChallengeRequest
 {
-    public byte[] Password { get; init; }
+    public byte[] AuthenticationPassword { get; init; }
 
-    public PasswordChallengeRequest(byte[] password)
+    public PasswordChallengeRequest(byte[] authenticationPassword)
     {
-        Password = password;
+        AuthenticationPassword = authenticationPassword;
     }
 }

--- a/Crypter.Core/Features/Keys/Queries/GetMasterKeyProofQuery.cs
+++ b/Crypter.Core/Features/Keys/Queries/GetMasterKeyProofQuery.cs
@@ -1,0 +1,78 @@
+﻿/*
+ * Copyright (C) 2023 Crypter File Transfer
+ *
+ * This file is part of the Crypter file transfer project.
+ *
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ *
+ * Contact the current copyright holder to discuss commercial license options.
+ */
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Crypter.Common.Contracts.Features.Keys;
+using Crypter.Common.Contracts.Features.UserAuthentication;
+using Crypter.Core.MediatorMonads;
+using Crypter.Core.Services;
+using Crypter.DataAccess;
+using EasyMonads;
+using Microsoft.EntityFrameworkCore;
+
+namespace Crypter.Core.Features.Keys.Queries;
+
+public record GetMasterKeyProofQuery
+    (Guid UserId, GetMasterKeyRecoveryProofRequest Data) : IEitherRequest<GetMasterKeyRecoveryProofError,
+        GetMasterKeyRecoveryProofResponse>;
+
+internal sealed class GetMasterKeyProofQueryHandler : IEitherRequestHandler<GetMasterKeyProofQuery,
+    GetMasterKeyRecoveryProofError, GetMasterKeyRecoveryProofResponse>
+{
+    private readonly DataContext _dataContext;
+    private readonly IUserAuthenticationService _userAuthenticationService;
+
+    public GetMasterKeyProofQueryHandler(DataContext dataContext, IUserAuthenticationService userAuthenticationService)
+    {
+        _dataContext = dataContext;
+        _userAuthenticationService = userAuthenticationService;
+    }
+    
+    public async Task<Either<GetMasterKeyRecoveryProofError, GetMasterKeyRecoveryProofResponse>> Handle(GetMasterKeyProofQuery request, CancellationToken cancellationToken)
+    {
+        Either<PasswordChallengeError, Unit> testPasswordResult = await _userAuthenticationService.TestUserPasswordAsync(request.UserId,
+            new PasswordChallengeRequest(request.Data.AuthenticationPassword), cancellationToken);
+        
+        return await testPasswordResult
+            .MatchAsync<Either<GetMasterKeyRecoveryProofError, GetMasterKeyRecoveryProofResponse>>(
+                error => GetMasterKeyRecoveryProofError.InvalidCredentials,
+                async _ =>
+                {
+                    byte[] recoveryProof = await _dataContext.UserMasterKeys
+                        .Where(x => x.Owner == request.UserId)
+                        .Select(x => x.RecoveryProof)
+                        .FirstOrDefaultAsync(cancellationToken);
+
+                    return recoveryProof is null
+                        ? GetMasterKeyRecoveryProofError.NotFound
+                        : new GetMasterKeyRecoveryProofResponse(recoveryProof);
+                },
+                GetMasterKeyRecoveryProofError.UnknownError);
+    }
+}

--- a/Crypter.Core/Features/Keys/Queries/GetMasterKeyQuery.cs
+++ b/Crypter.Core/Features/Keys/Queries/GetMasterKeyQuery.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * Copyright (C) 2023 Crypter File Transfer
+ *
+ * This file is part of the Crypter file transfer project.
+ *
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ *
+ * Contact the current copyright holder to discuss commercial license options.
+ */
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Crypter.Common.Contracts.Features.Keys;
+using Crypter.Core.MediatorMonads;
+using Crypter.DataAccess;
+using EasyMonads;
+using Microsoft.EntityFrameworkCore;
+
+namespace Crypter.Core.Features.Keys.Queries;
+
+public record GetMasterKeyQuery(Guid UserId) : IEitherRequest<GetMasterKeyError, GetMasterKeyResponse>;
+
+internal sealed class
+    GetMasterKeyQueryHandler : IEitherRequestHandler<GetMasterKeyQuery, GetMasterKeyError, GetMasterKeyResponse>
+{
+    private readonly DataContext _dataContext;
+
+    public GetMasterKeyQueryHandler(DataContext dataContext)
+    {
+        _dataContext = dataContext;
+    }
+    
+    public Task<Either<GetMasterKeyError, GetMasterKeyResponse>> Handle(GetMasterKeyQuery request, CancellationToken cancellationToken)
+    {
+        return Either<GetMasterKeyError, GetMasterKeyResponse>.FromRightAsync(
+            _dataContext.UserMasterKeys
+                .Where(x => x.Owner == request.UserId)
+                .Select(x => new GetMasterKeyResponse(x.EncryptedKey, x.Nonce))
+                .FirstOrDefaultAsync(cancellationToken), GetMasterKeyError.NotFound);
+    }
+}

--- a/Crypter.Core/MediatorMonads/IEitherRequest.cs
+++ b/Crypter.Core/MediatorMonads/IEitherRequest.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * Copyright (C) 2023 Crypter File Transfer
+ *
+ * This file is part of the Crypter file transfer project.
+ *
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ *
+ * Contact the current copyright holder to discuss commercial license options.
+ */
+
+using EasyMonads;
+using MediatR;
+
+namespace Crypter.Core.MediatorMonads;
+
+public interface IEitherRequest<TLeft, TRight> : IRequest<Either<TLeft, TRight>>
+{ }
+
+public interface IEitherRequestHandler<in TRequest, TLeft, TRight> : IRequestHandler<TRequest, Either<TLeft, TRight>>
+    where TRequest : IRequest<Either<TLeft, TRight>>
+{ }

--- a/Crypter.Core/MediatorMonads/IMaybeRequest.cs
+++ b/Crypter.Core/MediatorMonads/IMaybeRequest.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * Copyright (C) 2023 Crypter File Transfer
+ *
+ * This file is part of the Crypter file transfer project.
+ *
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ *
+ * Contact the current copyright holder to discuss commercial license options.
+ */
+
+using EasyMonads;
+using MediatR;
+
+namespace Crypter.Core.MediatorMonads;
+
+public interface IMaybeRequest<TResult> : IRequest<Maybe<TResult>>
+{ }
+
+public interface IMaybeRequestHandler<in TRequest, TResult> : IRequestHandler<TRequest, Maybe<TResult>>
+    where TRequest : IRequest<Maybe<TResult>>
+{ }

--- a/Crypter.Core/Services/UserAuthenticationService.cs
+++ b/Crypter.Core/Services/UserAuthenticationService.cs
@@ -236,7 +236,7 @@ public class UserAuthenticationService : IUserAuthenticationService
     public Task<Either<PasswordChallengeError, Unit>> TestUserPasswordAsync(Guid userId,
         PasswordChallengeRequest request, CancellationToken cancellationToken = default)
     {
-        return from suppliedPassword in ValidateRequestPassword(request.Password,
+        return from suppliedPassword in ValidateRequestPassword(request.AuthenticationPassword,
                 PasswordChallengeError.InvalidPassword).AsTask()
             from user in FetchUserAsync(userId, PasswordChallengeError.UnknownError, cancellationToken)
             from unit0 in VerifyUserPasswordIsMigrated(user, PasswordChallengeError.PasswordNeedsMigration)

--- a/Crypter.Test/Integration_Tests/UserKey_Tests/GetRecoveryKey_Tests.cs
+++ b/Crypter.Test/Integration_Tests/UserKey_Tests/GetRecoveryKey_Tests.cs
@@ -80,8 +80,7 @@ internal class GetRecoveryKey_Tests
         Either<InsertMasterKeyError, Unit> insertMasterKeyResult =
             await _client.UserKey.InsertMasterKeyAsync(insertMasterKeyRequest);
 
-        GetMasterKeyRecoveryProofRequest request = new GetMasterKeyRecoveryProofRequest(TestData.DefaultUsername,
-            registrationRequest.VersionedPassword.Password);
+        GetMasterKeyRecoveryProofRequest request = new GetMasterKeyRecoveryProofRequest(registrationRequest.VersionedPassword.Password);
         Either<GetMasterKeyRecoveryProofError, GetMasterKeyRecoveryProofResponse> result =
             await _client.UserKey.GetMasterKeyRecoveryProofAsync(request);
 
@@ -118,7 +117,7 @@ internal class GetRecoveryKey_Tests
 
         byte[] invalidPassword = "invalid"u8.ToArray();
         GetMasterKeyRecoveryProofRequest request =
-            new GetMasterKeyRecoveryProofRequest(TestData.DefaultUsername, invalidPassword);
+            new GetMasterKeyRecoveryProofRequest(invalidPassword);
         Either<GetMasterKeyRecoveryProofError, GetMasterKeyRecoveryProofResponse> result =
             await _client.UserKey.GetMasterKeyRecoveryProofAsync(request);
 

--- a/Crypter.Test/Integration_Tests/UserRecovery_Tests/SubmitRecovery_Tests.cs
+++ b/Crypter.Test/Integration_Tests/UserRecovery_Tests/SubmitRecovery_Tests.cs
@@ -124,8 +124,7 @@ internal class SubmitRecovery_Tests
             UserPasswordService userPasswordService = new UserPasswordService(_cryptoProvider);
             UserRecoveryService userRecoveryService =
                 new UserRecoveryService(_client, new DefaultCryptoProvider(), userPasswordService);
-            recoveryKey = await userRecoveryService.DeriveRecoveryKeyAsync(masterKey,
-                Username.From(TestData.DefaultUsername), registrationRequest.VersionedPassword);
+            recoveryKey = await userRecoveryService.DeriveRecoveryKeyAsync(masterKey, registrationRequest.VersionedPassword);
             recoveryKey.IfNone(Assert.Fail);
         }
 
@@ -236,8 +235,7 @@ internal class SubmitRecovery_Tests
         UserPasswordService userPasswordService = new UserPasswordService(_cryptoProvider);
         UserRecoveryService userRecoveryService =
             new UserRecoveryService(_client, new DefaultCryptoProvider(), userPasswordService);
-        RecoveryKey recoveryKey = await userRecoveryService.DeriveRecoveryKeyAsync(masterKey,
-                Username.From(TestData.DefaultUsername), registrationRequest.VersionedPassword)
+        RecoveryKey recoveryKey = await userRecoveryService.DeriveRecoveryKeyAsync(masterKey, registrationRequest.VersionedPassword)
             .SomeOrDefaultAsync(null);
 
         UserRecoveryEntity recoveryData = await dataContext.UserRecoveries

--- a/Crypter.Web/Shared/Modal/RecoveryKeyModal.razor.cs
+++ b/Crypter.Web/Shared/Modal/RecoveryKeyModal.razor.cs
@@ -67,7 +67,7 @@ public partial class RecoveryKeyModal
     {
         _recoveryKey = await UserKeysService.MasterKey
             .BindAsync(async masterKey =>
-                await UserRecoveryService.DeriveRecoveryKeyAsync(masterKey, username, versionedPassword))
+                await UserRecoveryService.DeriveRecoveryKeyAsync(masterKey, versionedPassword))
             .MatchAsync(
                 () => "An error occurred",
                 x => x.ToBase64String());


### PR DESCRIPTION
This PR moves two queries from an existing service to Mediator queries.

I also noticed the "Username" property in one of these requests was going entirely un-used.  Removed it.