### PR TITLE
Store enums as strings in the DB, instead of int

### DIFF
--- a/Crypter.DataAccess/DataContext.cs
+++ b/Crypter.DataAccess/DataContext.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2023 Crypter File Transfer
+ * Copyright (C) 2024 Crypter File Transfer
  *
  * This file is part of the Crypter file transfer project.
  *
@@ -31,7 +31,7 @@ namespace Crypter.DataAccess;
 
 public class DataContext : DbContext
 {
-    public const string _schemaName = "crypter";
+    public const string SchemaName = "crypter";
 
     /// <summary>
     /// This constructor is used during migrations.
@@ -41,27 +41,37 @@ public class DataContext : DbContext
     {
     }
 
-    public DbSet<UserEntity> Users { get; set; } = null!;
-    public DbSet<UserProfileEntity> UserProfiles { get; set; } = null!;
-    public DbSet<UserKeyPairEntity> UserKeyPairs { get; set; } = null!;
-    public DbSet<UserPrivacySettingEntity> UserPrivacySettings { get; set; } = null!;
-    public DbSet<UserEmailVerificationEntity> UserEmailVerifications { get; set; } = null!;
-    public DbSet<UserNotificationSettingEntity> UserNotificationSettings { get; set; } = null!;
-    public DbSet<UserTokenEntity> UserTokens { get; set; } = null!;
-    public DbSet<UserContactEntity> UserContacts { get; set; } = null!;
     public DbSet<AnonymousFileTransferEntity> AnonymousFileTransfers { get; set; } = null!;
     public DbSet<AnonymousMessageTransferEntity> AnonymousMessageTransfers { get; set; } = null!;
-    public DbSet<UserFileTransferEntity> UserFileTransfers { get; set; } = null!;
-    public DbSet<UserMessageTransferEntity> UserMessageTransfers { get; set; } = null!;
-    public DbSet<UserFailedLoginEntity> UserFailedLoginAttempts { get; set; } = null!;
-    public DbSet<UserMasterKeyEntity> UserMasterKeys { get; set; } = null!;
     public DbSet<UserConsentEntity> UserConsents { get; set; } = null!;
+    public DbSet<UserContactEntity> UserContacts { get; set; } = null!;
+    public DbSet<UserEmailVerificationEntity> UserEmailVerifications { get; set; } = null!;
+    public DbSet<UserEntity> Users { get; set; } = null!;
+    public DbSet<UserFailedLoginEntity> UserFailedLoginAttempts { get; set; } = null!;
+    public DbSet<UserFileTransferEntity> UserFileTransfers { get; set; } = null!;
+    public DbSet<UserKeyPairEntity> UserKeyPairs { get; set; } = null!;
+    public DbSet<UserMasterKeyEntity> UserMasterKeys { get; set; } = null!;
+    public DbSet<UserMessageTransferEntity> UserMessageTransfers { get; set; } = null!;
+    public DbSet<UserNotificationSettingEntity> UserNotificationSettings { get; set; } = null!;
+    public DbSet<UserPrivacySettingEntity> UserPrivacySettings { get; set; } = null!;
+    public DbSet<UserProfileEntity> UserProfiles { get; set; } = null!;
     public DbSet<UserRecoveryEntity> UserRecoveries { get; set; } = null!;
-
-    protected override void OnModelCreating(ModelBuilder builder)
+    public DbSet<UserTokenEntity> UserTokens { get; set; } = null!;
+    
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
-        builder.HasPostgresExtension("citext")
-            .HasDefaultSchema(_schemaName)
+        base.ConfigureConventions(configurationBuilder);
+        
+        configurationBuilder.Properties<Enum>()
+            .HaveConversion<string>();
+    }
+    
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        
+        modelBuilder.HasPostgresExtension("citext")
+            .HasDefaultSchema(SchemaName)
             .ApplyConfigurationsFromAssembly(typeof(DataContext).Assembly);
     }
 }

--- a/Crypter.DataAccess/DependencyInjection.cs
+++ b/Crypter.DataAccess/DependencyInjection.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2023 Crypter File Transfer
+ * Copyright (C) 2024 Crypter File Transfer
  *
  * This file is part of the Crypter file transfer project.
  *
@@ -43,13 +43,13 @@ public static class DependencyInjection
         {
             optionsBuilder.UseNpgsql(connectionString, npgsqlOptionsBuilder =>
                 {
-                    npgsqlOptionsBuilder.EnableRetryOnFailure(5, TimeSpan.FromSeconds(5), new[] { "57P01" });
+                    npgsqlOptionsBuilder.EnableRetryOnFailure(5, TimeSpan.FromSeconds(5), ["57P01"]);
                     npgsqlOptionsBuilder.MigrationsHistoryTable(HistoryRepository.DefaultTableName,
-                        DataContext._schemaName);
+                        DataContext.SchemaName);
                 })
                 .LogTo(
-                    filter: (eventId, level) => eventId.Id == CoreEventId.ExecutionStrategyRetrying,
-                    logger: (eventData) =>
+                    filter: (eventId, _) => eventId.Id == CoreEventId.ExecutionStrategyRetrying,
+                    logger: eventData =>
                     {
                         ExecutionStrategyEventData? retryEventData = eventData as ExecutionStrategyEventData;
                         IReadOnlyList<Exception>? exceptions = retryEventData?.ExceptionsEncountered;

--- a/Crypter.DataAccess/Entities/UserConsentEntity.cs
+++ b/Crypter.DataAccess/Entities/UserConsentEntity.cs
@@ -79,7 +79,8 @@ public class UserConsentEntityConfiguration : IEntityTypeConfiguration<UserConse
         builder.Property(x => x.Id)
             .UseIdentityAlwaysColumn();
 
-        builder.Property(x => x.Active);
+        builder.Property(x => x.ConsentType)
+            .HasMaxLength(16);
 
         builder.HasIndex(x => x.Owner);
 

--- a/Crypter.DataAccess/Entities/UserPrivacySettingEntity.cs
+++ b/Crypter.DataAccess/Entities/UserPrivacySettingEntity.cs
@@ -59,6 +59,15 @@ public class UserPrivacySettingEntityConfiguration : IEntityTypeConfiguration<Us
 
         builder.HasKey(x => x.Owner);
 
+        builder.Property(x => x.Visibility)
+            .HasMaxLength(16);
+        
+        builder.Property(x => x.ReceiveFiles)
+            .HasMaxLength(16);
+        
+        builder.Property(x => x.ReceiveMessages)
+            .HasMaxLength(16);
+        
         builder.HasOne(x => x.User)
             .WithOne(x => x.PrivacySetting)
             .HasForeignKey<UserPrivacySettingEntity>(x => x.Owner)

--- a/Crypter.DataAccess/Entities/UserTokenEntity.cs
+++ b/Crypter.DataAccess/Entities/UserTokenEntity.cs
@@ -61,6 +61,9 @@ public class UserTokenEntityConfiguration : IEntityTypeConfiguration<UserTokenEn
 
         builder.HasKey(x => x.Id);
 
+        builder.Property(x => x.Type)
+            .HasMaxLength(16);
+        
         builder.HasOne(x => x.User)
             .WithMany(x => x.Tokens)
             .HasForeignKey(x => x.Owner)

--- a/Crypter.DataAccess/Migrations/20240325024438_SwitchEnumsToStrings.Designer.cs
+++ b/Crypter.DataAccess/Migrations/20240325024438_SwitchEnumsToStrings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Crypter.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Crypter.DataAccess.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20240325024438_SwitchEnumsToStrings")]
+    partial class SwitchEnumsToStrings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Crypter.DataAccess/Migrations/20240325024438_SwitchEnumsToStrings.cs
+++ b/Crypter.DataAccess/Migrations/20240325024438_SwitchEnumsToStrings.cs
@@ -1,0 +1,143 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Crypter.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class SwitchEnumsToStrings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Type",
+                schema: "crypter",
+                table: "UserToken",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+            
+            migrationBuilder.Sql(
+                "UPDATE crypter.\"UserToken\" SET \"Type\" = 'Authentication' WHERE \"Type\" = '0';" +
+                "UPDATE crypter.\"UserToken\" SET \"Type\" = 'Session' WHERE \"Type\" = '1';" +
+                "UPDATE crypter.\"UserToken\" SET \"Type\" = 'Device' WHERE \"Type\" = '2';");
+            
+            migrationBuilder.AlterColumn<string>(
+                name: "Visibility",
+                schema: "crypter",
+                table: "UserPrivacySetting",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.Sql(
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"Visibility\" = 'None' WHERE \"Visibility\" = '0';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"Visibility\" = 'Contacts' WHERE \"Visibility\" = '1';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"Visibility\" = 'Authenticated' WHERE \"Visibility\" = '2';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"Visibility\" = 'Everyone' WHERE \"Visibility\" = '3';");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ReceiveMessages",
+                schema: "crypter",
+                table: "UserPrivacySetting",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.Sql(
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveMessages\" = 'None' WHERE \"ReceiveMessages\" = '0';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveMessages\" = 'ExchangedKeys' WHERE \"ReceiveMessages\" = '1';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveMessages\" = 'Contacts' WHERE \"ReceiveMessages\" = '2';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveMessages\" = 'Authenticated' WHERE \"ReceiveMessages\" = '3';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveMessages\" = 'Everyone' WHERE \"ReceiveMessages\" = '4';");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ReceiveFiles",
+                schema: "crypter",
+                table: "UserPrivacySetting",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.Sql(
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveFiles\" = 'None' WHERE \"ReceiveFiles\" = '0';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveFiles\" = 'ExchangedKeys' WHERE \"ReceiveFiles\" = '1';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveFiles\" = 'Contacts' WHERE \"ReceiveFiles\" = '2';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveFiles\" = 'Authenticated' WHERE \"ReceiveFiles\" = '3';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveFiles\" = 'Everyone' WHERE \"ReceiveFiles\" = '4';");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ConsentType",
+                schema: "crypter",
+                table: "UserConsent",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.Sql(
+                "UPDATE crypter.\"UserConsent\" SET \"ConsentType\" = 'TermsOfService' WHERE \"ConsentType\" = '0';" +
+                "UPDATE crypter.\"UserConsent\" SET \"ConsentType\" = 'PrivacyPolicy' WHERE \"ConsentType\" = '1';" +
+                "UPDATE crypter.\"UserConsent\" SET \"ConsentType\" = 'RecoveryKeyRisks' WHERE \"ConsentType\" = '2';");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "UPDATE crypter.\"UserToken\" SET \"Type\" = '0' WHERE \"Type\" = 'Authentication';" +
+                "UPDATE crypter.\"UserToken\" SET \"Type\" = '1' WHERE \"Type\" = 'Session';" + 
+                "UPDATE crypter.\"UserToken\" SET \"Type\" = '2' WHERE \"Type\" = 'Device';");
+
+            migrationBuilder.Sql(
+                "ALTER TABLE crypter.\"UserToken\" ALTER COLUMN \"Type\" TYPE INT USING \"Type\"::integer;");
+            
+            migrationBuilder.Sql(
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"Visibility\" = '0' WHERE \"Visibility\" = 'None';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"Visibility\" = '1' WHERE \"Visibility\" = 'Contacts';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"Visibility\" = '2' WHERE \"Visibility\" = 'Authenticated';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"Visibility\" = '3' WHERE \"Visibility\" = 'Everyone';");
+            
+            migrationBuilder.Sql(
+                "ALTER TABLE crypter.\"UserPrivacySetting\" ALTER COLUMN \"Visibility\" TYPE INT USING \"Visibility\"::integer;");
+
+            migrationBuilder.Sql(
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveMessages\" = '0' WHERE \"ReceiveMessages\" = 'None';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveMessages\" = '1' WHERE \"ReceiveMessages\" = 'ExchangedKeys';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveMessages\" = '2' WHERE \"ReceiveMessages\" = 'Contacts';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveMessages\" = '3' WHERE \"ReceiveMessages\" = 'Authenticated';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveMessages\" = '4' WHERE \"ReceiveMessages\" = 'Everyone';");
+            
+            migrationBuilder.Sql(
+                "ALTER TABLE crypter.\"UserPrivacySetting\" ALTER COLUMN \"ReceiveMessages\" TYPE INT USING \"ReceiveMessages\"::integer;");
+
+            migrationBuilder.Sql(
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveFiles\" = '0' WHERE \"ReceiveFiles\" = 'None';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveFiles\" = '1' WHERE \"ReceiveFiles\" = 'ExchangedKeys';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveFiles\" = '2' WHERE \"ReceiveFiles\" = 'Contacts';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveFiles\" = '3' WHERE \"ReceiveFiles\" = 'Authenticated';" +
+                "UPDATE crypter.\"UserPrivacySetting\" SET \"ReceiveFiles\" = '4' WHERE \"ReceiveFiles\" = 'Everyone';");
+            
+            migrationBuilder.Sql(
+                "ALTER TABLE crypter.\"UserPrivacySetting\" ALTER COLUMN \"ReceiveFiles\" TYPE INT USING \"ReceiveFiles\"::integer;");
+            
+            migrationBuilder.Sql(
+                "UPDATE crypter.\"UserConsent\" SET \"ConsentType\" = '0' WHERE \"ConsentType\" = 'TermsOfService';" +
+                "UPDATE crypter.\"UserConsent\" SET \"ConsentType\" = '1' WHERE \"ConsentType\" = 'PrivacyPolicy';" +
+                "UPDATE crypter.\"UserConsent\" SET \"ConsentType\" = '2' WHERE \"ConsentType\" = 'RecoveryKeyRisks';");
+            
+            migrationBuilder.Sql(
+                "ALTER TABLE crypter.\"UserConsent\" ALTER COLUMN \"ConsentType\" TYPE INT USING \"ConsentType\"::integer;");
+        }
+    }
+}


### PR DESCRIPTION
Store the string representation of C# enums in the database, rather than the corresponding integer values.

Attempt integer parsing within relevant `HasConversion` blocks for backwards-compatibility.