### PR TITLE
Resolve unhandled exception when an invalid hashId is provided

### DIFF
--- a/Crypter.Core/Features/Transfer/Commands/GetUserFileCiphertextCommand.cs
+++ b/Crypter.Core/Features/Transfer/Commands/GetUserFileCiphertextCommand.cs
@@ -73,25 +73,32 @@ internal class GetUserFileCiphertextCommandHandler
 
     public async Task<Either<DownloadTransferCiphertextError, FileStream>> Handle(GetUserFileCiphertextCommand request, CancellationToken cancellationToken)
     {
-        Guid itemId = _hashIdService.Decode(request.HashId);
+        Guid? itemId = _hashIdService.Decode(request.HashId)
+            .Match((Guid?)null, x => x);
+
+        if (!itemId.HasValue)
+        {
+            return DownloadTransferCiphertextError.NotFound;
+        }
+        
         Guid? nullableRequesterUserId = request.RequesterId
             .Match<Guid?>(() => null, x => x);
         
-        return await GetFileStreamAsync(itemId, nullableRequesterUserId, request.Proof)
+        return await GetFileStreamAsync(itemId.Value, nullableRequesterUserId, request.Proof)
             .DoRightAsync(async _ =>
             {
-                SuccessfulTransferDownloadEvent downloadEvent = new SuccessfulTransferDownloadEvent(itemId, TransferItemType.File, TransferUserType.User, nullableRequesterUserId, !_transferHasRecipient, DateTimeOffset.UtcNow);
+                SuccessfulTransferDownloadEvent downloadEvent = new SuccessfulTransferDownloadEvent(itemId.Value, TransferItemType.File, TransferUserType.User, nullableRequesterUserId, !_transferHasRecipient, DateTimeOffset.UtcNow);
                 await _publisher.Publish(downloadEvent, CancellationToken.None);
             })
             .DoLeftOrNeitherAsync(
                 async error =>
                 {
-                    FailedTransferDownloadEvent failedTransferDownloadEvent = new FailedTransferDownloadEvent(itemId, TransferItemType.File, nullableRequesterUserId, error, DateTimeOffset.UtcNow);
+                    FailedTransferDownloadEvent failedTransferDownloadEvent = new FailedTransferDownloadEvent(itemId.Value, TransferItemType.File, nullableRequesterUserId, error, DateTimeOffset.UtcNow);
                     await _publisher.Publish(failedTransferDownloadEvent, CancellationToken.None);
                 },
                 async () =>
                 {
-                    FailedTransferDownloadEvent failedTransferDownloadEvent = new FailedTransferDownloadEvent(itemId, TransferItemType.File, nullableRequesterUserId, DownloadTransferCiphertextError.UnknownError, DateTimeOffset.UtcNow);
+                    FailedTransferDownloadEvent failedTransferDownloadEvent = new FailedTransferDownloadEvent(itemId.Value, TransferItemType.File, nullableRequesterUserId, DownloadTransferCiphertextError.UnknownError, DateTimeOffset.UtcNow);
                     await _publisher.Publish(failedTransferDownloadEvent, CancellationToken.None);
                 });
     }

--- a/Crypter.Core/Features/Transfer/Queries/AnonymousMessagePreviewQuery.cs
+++ b/Crypter.Core/Features/Transfer/Queries/AnonymousMessagePreviewQuery.cs
@@ -62,26 +62,33 @@ internal class AnonymousMessagePreviewQueryHandler
     
     public async Task<Either<TransferPreviewError, MessageTransferPreviewResponse>> Handle(AnonymousMessagePreviewQuery request, CancellationToken cancellationToken)
     {
-        Guid itemId = _hashIdService.Decode(request.HashId);
-        return await GetAnonymousMessagePreviewAsync(itemId)
+        Guid? itemId = _hashIdService.Decode(request.HashId)
+            .Match((Guid?)null, x => x);
+
+        if (!itemId.HasValue)
+        {
+            return TransferPreviewError.NotFound;
+        }
+        
+        return await GetAnonymousMessagePreviewAsync(itemId.Value)
             .DoRightAsync(
             async _ =>
             {
                 SuccessfulTransferPreviewEvent successfulTransferPreviewEvent =
-                    new SuccessfulTransferPreviewEvent(itemId, TransferItemType.Message, null, DateTimeOffset.UtcNow);
+                    new SuccessfulTransferPreviewEvent(itemId.Value, TransferItemType.Message, null, DateTimeOffset.UtcNow);
                 await _publisher.Publish(successfulTransferPreviewEvent, CancellationToken.None);
             })
             .DoLeftOrNeitherAsync(
                 async error =>
                 {
                     FailedTransferPreviewEvent failedTransferPreviewEvent =
-                        new FailedTransferPreviewEvent(itemId, TransferItemType.Message, null, error, DateTimeOffset.UtcNow);
+                        new FailedTransferPreviewEvent(itemId.Value, TransferItemType.Message, null, error, DateTimeOffset.UtcNow);
                     await _publisher.Publish(failedTransferPreviewEvent, CancellationToken.None);
                 },
                 async () =>
                 {
                     FailedTransferPreviewEvent failedTransferPreviewEvent =
-                        new FailedTransferPreviewEvent(itemId, TransferItemType.Message, null, TransferPreviewError.UnknownError, DateTimeOffset.UtcNow);
+                        new FailedTransferPreviewEvent(itemId.Value, TransferItemType.Message, null, TransferPreviewError.UnknownError, DateTimeOffset.UtcNow);
                     await _publisher.Publish(failedTransferPreviewEvent, CancellationToken.None);
                 });
     }

--- a/Crypter.Core/Features/Transfer/Queries/UserFilePreviewQuery.cs
+++ b/Crypter.Core/Features/Transfer/Queries/UserFilePreviewQuery.cs
@@ -62,28 +62,34 @@ internal class UserFilePreviewQueryHandler
     
     public async Task<Either<TransferPreviewError, FileTransferPreviewResponse>> Handle(UserFilePreviewQuery request, CancellationToken cancellationToken)
     {
-        Guid itemId = _hashIdService.Decode(request.HashId);
+        Guid? itemId = _hashIdService.Decode(request.HashId)
+            .Match((Guid?)null, x => x);
+
+        if (!itemId.HasValue)
+        {
+            return TransferPreviewError.NotFound;
+        }
         
         Guid? nullableRequesterUserId = request.RequesterId
             .Match<Guid?>(() => null, x => x);
 
-        return await GetUserFilePreviewAsync(itemId, nullableRequesterUserId)
+        return await GetUserFilePreviewAsync(itemId.Value, nullableRequesterUserId)
             .DoRightAsync(async _ =>
             {
-                SuccessfulTransferPreviewEvent successfulTransferPreviewEvent = new SuccessfulTransferPreviewEvent(itemId, TransferItemType.File, nullableRequesterUserId, DateTimeOffset.UtcNow);
+                SuccessfulTransferPreviewEvent successfulTransferPreviewEvent = new SuccessfulTransferPreviewEvent(itemId.Value, TransferItemType.File, nullableRequesterUserId, DateTimeOffset.UtcNow);
                 await _publisher.Publish(successfulTransferPreviewEvent, CancellationToken.None);
             })
             .DoLeftOrNeitherAsync(
                 async error =>
                 {
                     FailedTransferPreviewEvent failedTransferPreviewEvent =
-                        new FailedTransferPreviewEvent(itemId, TransferItemType.File, nullableRequesterUserId, error, DateTimeOffset.UtcNow);
+                        new FailedTransferPreviewEvent(itemId.Value, TransferItemType.File, nullableRequesterUserId, error, DateTimeOffset.UtcNow);
                     await _publisher.Publish(failedTransferPreviewEvent, CancellationToken.None);
                 },
                 async () =>
                 {
                     FailedTransferPreviewEvent failedTransferPreviewEvent =
-                        new FailedTransferPreviewEvent(itemId, TransferItemType.File, nullableRequesterUserId, TransferPreviewError.UnknownError, DateTimeOffset.UtcNow);
+                        new FailedTransferPreviewEvent(itemId.Value, TransferItemType.File, nullableRequesterUserId, TransferPreviewError.UnknownError, DateTimeOffset.UtcNow);
                     await _publisher.Publish(failedTransferPreviewEvent, CancellationToken.None);
                 });
     }

--- a/Crypter.Core/Services/HashIdService.cs
+++ b/Crypter.Core/Services/HashIdService.cs
@@ -26,6 +26,7 @@
 
 using System;
 using Crypter.Core.Settings;
+using EasyMonads;
 using HashidsNet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -36,7 +37,7 @@ namespace Crypter.Core.Services;
 public interface IHashIdService
 {
     string Encode(Guid id);
-    Guid Decode(string hash);
+    Maybe<Guid> Decode(string hash);
 }
 
 public static class HashIdServiceExtensions
@@ -69,7 +70,7 @@ public class HashIdService : IHashIdService
         return _lib.EncodeHex(hexString);
     }
 
-    public Guid Decode(string hash)
+    public Maybe<Guid> Decode(string hash)
     {
         string hexString = _lib.DecodeHex(hash);
 
@@ -81,6 +82,13 @@ public class HashIdService : IHashIdService
             bytes[i] = Convert.ToByte(hexString.Substring(i * 2, 2), 16);
         }
 
-        return new Guid(bytes);
+        try
+        {
+            return new Guid(bytes);
+        }
+        catch
+        {
+            return Maybe<Guid>.None;
+        }
     }
 }

--- a/Crypter.Test/Core_Tests/Services_Tests/HashIdService_Tests.cs
+++ b/Crypter.Test/Core_Tests/Services_Tests/HashIdService_Tests.cs
@@ -27,6 +27,7 @@
 using System;
 using Crypter.Core.Services;
 using Crypter.Core.Settings;
+using EasyMonads;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
 
@@ -55,8 +56,8 @@ public class HashIdService_Tests
         Guid guid = Guid.NewGuid();
 
         string hash = _sut!.Encode(guid);
-        Guid decodedHash = _sut.Decode(hash);
+        Maybe<Guid> decodedHash = _sut.Decode(hash);
 
-        Assert.That(decodedHash, Is.EqualTo(guid));
+        Assert.That(decodedHash.SomeOrDefault(), Is.EqualTo(guid));
     }
 }


### PR DESCRIPTION
Noticed some unhandled exceptions in production.  Not every item id / hash id provided via the API will be valid.  Handle more gracefully.