### PR TITLE
Only register the service worker when downloading a file

### DIFF
--- a/Crypter.API/Controllers/FileTransferController.cs
+++ b/Crypter.API/Controllers/FileTransferController.cs
@@ -55,7 +55,15 @@ public class FileTransferController : TransferControllerBase
     {
         _sender = sender;
     }
-
+    
+    /// <summary>
+    /// The ideal way to upload a file of any size.
+    /// However, the endpoints to receive chunked files is preferred while this Chromium issue remains unaddressed:
+    /// https://issues.chromium.org/issues/339788214
+    /// </summary>
+    /// <param name="username"></param>
+    /// <param name="request"></param>
+    /// <returns></returns>
     [HttpPost]
     [MaybeAuthorize]
     [RequestFormLimits(MultipartBodyLengthLimit = long.MaxValue)]

--- a/Crypter.Web/Caddyfile
+++ b/Crypter.Web/Caddyfile
@@ -6,8 +6,6 @@
 		format console
 	}
 
-    rewrite /serviceWorker /srv/js/dist/serviceWorker
-
 	handle /api/* {
 		request_body {
 			max_size {$CADDY_MAX_REQUEST_BODY}
@@ -16,10 +14,23 @@
 		reverse_proxy {$CRYPTER_API_BASE}
 	}
 
-    handle /srv/js/dist/serviceWorker {
-        root * /srv/js/dist/serviceWorker
+    handle /serviceWorker {
+        root * /srv
+        rewrite * js/dist/serviceWorker/serviceWorker.js
     
-        try_files {path} /serviceWorker.js
+        file_server {
+            precompressed br gzip
+        }
+        
+        header {
+            Service-Worker-Allowed "/"
+            Service-Worker "script"
+        }
+    }
+    
+    handle /serviceWorker.noOp {
+        root * /srv
+        rewrite * js/dist/serviceWorker.noOp/serviceWorker.noOp.js
     
         file_server {
             precompressed br gzip

--- a/Crypter.Web/Crypter.Web.csproj
+++ b/Crypter.Web/Crypter.Web.csproj
@@ -36,6 +36,7 @@
       <Exec Command="pnpm run buildFunctions" />
       <Exec Command="pnpm run buildFileSaver" />
       <Exec Command="pnpm run buildServiceWorker" />
+      <Exec Command="pnpm run buildServiceWorkerNoOp" />
    </Target>
    
 </Project>

--- a/Crypter.Web/Npm/src/fileSaver/download.ts
+++ b/Crypter.Web/Npm/src/fileSaver/download.ts
@@ -29,35 +29,30 @@ function createDownloadIframe(src: string) {
     return iframe;
 }
 
-export async function registerServiceWorkerInternal() :Promise<void> {
+export async function registerServiceWorker() :Promise<void> {
     if (serviceWorkerNotSupported()) {
         throw new Error('Saving file via stream is not supported by this browser');
     }
 
     await navigator.serviceWorker.register('/serviceWorker',{
         scope: '/'
-    }).then((x) => {
+    }).then(() => {
         console.log("Registered service worker");
     });
     
     serviceWorkerKeepAlive();
 }
 
-export async function unregisterServiceWorkerInternal() : Promise<void> {
+export async function registerNoOpServiceWorker() : Promise<void> {
     if (serviceWorkerNotSupported()) {
         return;
     }
-    
-    const serviceWorkerRegistrations = await navigator.serviceWorker.getRegistrations();
-    for (const registration of serviceWorkerRegistrations) {
-        await registration.unregister().then(x => {
-            if (x) {
-                console.log("Unregistered service worker");
-            } else {
-                console.error("Failed to unregister service worker.")
-            }
-        });
-    }
+
+    await navigator.serviceWorker.register('/serviceWorker.noOp',{
+        scope: '/'
+    }).then(() => {
+        console.log("Registered no op service worker");
+    });
 }
 
 export async function openDownloadStream(metaData: FileMetaData) {
@@ -91,7 +86,11 @@ export async function openDownloadStream(metaData: FileMetaData) {
 
 function serviceWorkerKeepAlive() {
     const interval = setInterval(() => {
-        wakeUpServiceWorker().catch(() => clearInterval(interval));
+        wakeUpServiceWorker()
+        .catch((error) => {
+            console.error(error);
+            clearInterval(interval)
+        });
     }, 10000);
 }
 

--- a/Crypter.Web/Npm/src/fileSaver/download.ts
+++ b/Crypter.Web/Npm/src/fileSaver/download.ts
@@ -29,7 +29,7 @@ function createDownloadIframe(src: string) {
     return iframe;
 }
 
-export async function registerServiceWorker() :Promise<void> {
+export async function registerServiceWorkerInternal() :Promise<void> {
     if (serviceWorkerNotSupported()) {
         throw new Error('Saving file via stream is not supported by this browser');
     }
@@ -37,9 +37,27 @@ export async function registerServiceWorker() :Promise<void> {
     await navigator.serviceWorker.register('/serviceWorker',{
         scope: '/'
     }).then((x) => {
-        console.log("Service worker registered");
+        console.log("Registered service worker");
     });
+    
     serviceWorkerKeepAlive();
+}
+
+export async function unregisterServiceWorkerInternal() : Promise<void> {
+    if (serviceWorkerNotSupported()) {
+        return;
+    }
+    
+    const serviceWorkerRegistrations = await navigator.serviceWorker.getRegistrations();
+    for (const registration of serviceWorkerRegistrations) {
+        await registration.unregister().then(x => {
+            if (x) {
+                console.log("Unregistered service worker");
+            } else {
+                console.error("Failed to unregister service worker.")
+            }
+        });
+    }
 }
 
 export async function openDownloadStream(metaData: FileMetaData) {

--- a/Crypter.Web/Npm/src/fileSaver/fileSaver.ts
+++ b/Crypter.Web/Npm/src/fileSaver/fileSaver.ts
@@ -8,10 +8,10 @@
  */
 
 import {
-    registerServiceWorkerInternal,
+    registerServiceWorker,
     openDownloadStream,
-    unregisterServiceWorkerInternal,
-    serviceWorkerNotSupported
+    serviceWorkerNotSupported,
+    registerNoOpServiceWorker
 } from "./download";
 import { saveAs } from "file-saver";
 import FileMetaData from "./interfaces/fileMetaData";
@@ -23,7 +23,7 @@ class FileSaver {
     public IsServiceWorkerAvailable: boolean = false;
 
     public async initialize() {
-        await registerServiceWorkerInternal()
+        await registerServiceWorker()
             .then(() => this.IsServiceWorkerAvailable = true)
             .catch((error) : void => {
                 this.IsServiceWorkerAvailable = false;
@@ -31,8 +31,8 @@ class FileSaver {
             });
     }
 
-    public async unregisterServiceWorker() {
-        await unregisterServiceWorkerInternal();
+    public async deactivateServiceWorker() {
+        await registerNoOpServiceWorker();
     }
     
     public static getInstance(): FileSaver
@@ -89,9 +89,9 @@ export async function initializeAsync() : Promise<void> {
     await thisInstance.initialize();
 }
 
-export async function unregisterServiceWorkerAsync() : Promise<void> {
+export async function deactivateServiceWorkerAsync() : Promise<void> {
     let thisInstance: FileSaver = FileSaver.getInstance();
-    await thisInstance.unregisterServiceWorker();
+    await thisInstance.deactivateServiceWorker();
 }
 
 export function browserSupportsStreamingDownloads(): boolean {

--- a/Crypter.Web/Npm/src/fileSaver/serviceWorker.noOp.ts
+++ b/Crypter.Web/Npm/src/fileSaver/serviceWorker.noOp.ts
@@ -1,0 +1,6 @@
+self.addEventListener('install', () => {
+    // Skip over the "waiting" lifecycle state, to ensure that our
+    // new service worker is activated immediately, even if there's
+    // another tab open controlled by our older service worker code.
+    void (self as any).skipWaiting();
+});

--- a/Crypter.Web/Npm/src/fileSaver/serviceWorker.ts
+++ b/Crypter.Web/Npm/src/fileSaver/serviceWorker.ts
@@ -61,7 +61,7 @@ function createDownloadStream(port: MessagePort) {
     });
 }
 
-self.addEventListener('install', (event) => {
+self.addEventListener('install', () => {
     void (self as any).skipWaiting();
 });
 

--- a/Crypter.Web/Services/FileSaverService.cs
+++ b/Crypter.Web/Services/FileSaverService.cs
@@ -37,7 +37,7 @@ public interface IFileSaverService
     bool SupportsStreamingDownloads { get; }
     
     Task InitializeAsync(bool registerServiceWorker = false);
-    Task UnregisterServiceWorkerAsync();
+    Task DeactivateServiceWorkerAsync();
     Task SaveFileAsync(Stream stream, string fileName, string mimeType, long? size);
 }
 
@@ -61,12 +61,12 @@ public class FileSaverService(IJSRuntime jsRuntime) : IFileSaverService
         }
     }
 
-    public async Task UnregisterServiceWorkerAsync()
+    public async Task DeactivateServiceWorkerAsync()
     {
         if (OperatingSystem.IsBrowser())
         {
             _moduleReference = await jsRuntime.InvokeAsync<IJSInProcessObjectReference>("import", "../js/dist/fileSaver/fileSaver.bundle.js");
-            await _moduleReference.InvokeVoidAsync("unregisterServiceWorkerAsync");
+            await _moduleReference.InvokeVoidAsync("deactivateServiceWorkerAsync");
         }
     }
     

--- a/Crypter.Web/Services/FileSaverService.cs
+++ b/Crypter.Web/Services/FileSaverService.cs
@@ -36,7 +36,8 @@ public interface IFileSaverService
 {
     bool SupportsStreamingDownloads { get; }
     
-    Task InitializeAsync();
+    Task InitializeAsync(bool registerServiceWorker = false);
+    Task UnregisterServiceWorkerAsync();
     Task SaveFileAsync(Stream stream, string fileName, string mimeType, long? size);
 }
 
@@ -46,15 +47,29 @@ public class FileSaverService(IJSRuntime jsRuntime) : IFileSaverService
     public bool SupportsStreamingDownloads { get => BrowserSupportsStreamingDownloads(); }
     private IJSInProcessObjectReference? _moduleReference;
 
-    public async Task InitializeAsync()
+    public async Task InitializeAsync(bool registerServiceWorker = false)
+    {
+        if (OperatingSystem.IsBrowser())
+        {
+            _moduleReference ??= await jsRuntime.InvokeAsync<IJSInProcessObjectReference>("import",
+                "../js/dist/fileSaver/fileSaver.bundle.js");
+
+            if (registerServiceWorker)
+            {
+                await _moduleReference.InvokeVoidAsync("initializeAsync");
+            }
+        }
+    }
+
+    public async Task UnregisterServiceWorkerAsync()
     {
         if (OperatingSystem.IsBrowser())
         {
             _moduleReference = await jsRuntime.InvokeAsync<IJSInProcessObjectReference>("import", "../js/dist/fileSaver/fileSaver.bundle.js");
-            await _moduleReference.InvokeVoidAsync("initializeAsync");
+            await _moduleReference.InvokeVoidAsync("unregisterServiceWorkerAsync");
         }
     }
-
+    
     public async Task SaveFileAsync(Stream stream, string fileName, string mimeType, long? size)
     {
         using DotNetStreamReference streamReference = new DotNetStreamReference(stream, leaveOpen: false);

--- a/Crypter.Web/Shared/Transfer/DownloadFileTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/DownloadFileTransfer.razor.cs
@@ -45,9 +45,6 @@ public partial class DownloadFileTransfer
     [Inject]
     private IJSRuntime JSRuntime { get; init; } = null!;
 
-    [Inject]
-    private IFileSaverService FileSaverService { get; init; } = null!;
-
     protected bool FileCannotBeDownloadedOnThisBrowser { get; set; } = false;
     
     private long _maxBufferSizeMB = 0;
@@ -97,6 +94,8 @@ public partial class DownloadFileTransfer
             ErrorMessage = "Download handler not assigned.";
             return;
         }
+
+        await FileSaverService.InitializeAsync(true);
         
         DecryptionInProgress = true;
 
@@ -116,6 +115,7 @@ public partial class DownloadFileTransfer
                 .DoRightAsync(async decryptionStream =>
                 {
                     await FileSaverService.SaveFileAsync(decryptionStream, _fileName, _contentType, null);
+                    await FileSaverService.UnregisterServiceWorkerAsync();
                     DecryptionComplete = true;
                     await decryptionStream.DisposeAsync();
                 })

--- a/Crypter.Web/Shared/Transfer/DownloadFileTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/DownloadFileTransfer.razor.cs
@@ -115,9 +115,9 @@ public partial class DownloadFileTransfer
                 .DoRightAsync(async decryptionStream =>
                 {
                     await FileSaverService.SaveFileAsync(decryptionStream, _fileName, _contentType, null);
-                    await FileSaverService.DeactivateServiceWorkerAsync();
                     DecryptionComplete = true;
                     await decryptionStream.DisposeAsync();
+                    await FileSaverService.DeactivateServiceWorkerAsync();
                 })
                 .DoLeftOrNeitherAsync(
                     HandleDownloadError,

--- a/Crypter.Web/Shared/Transfer/DownloadFileTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/DownloadFileTransfer.razor.cs
@@ -115,7 +115,7 @@ public partial class DownloadFileTransfer
                 .DoRightAsync(async decryptionStream =>
                 {
                     await FileSaverService.SaveFileAsync(decryptionStream, _fileName, _contentType, null);
-                    await FileSaverService.UnregisterServiceWorkerAsync();
+                    await FileSaverService.DeactivateServiceWorkerAsync();
                     DecryptionComplete = true;
                     await decryptionStream.DisposeAsync();
                 })

--- a/Crypter.Web/Shared/Transfer/DownloadMessageTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/DownloadMessageTransfer.razor.cs
@@ -70,6 +70,8 @@ public partial class DownloadMessageTransfer
             ErrorMessage = "Download handler not assigned.";
             return;
         }
+
+        await FileSaverService.UnregisterServiceWorkerAsync();
         
         DecryptionInProgress = true;
 

--- a/Crypter.Web/Shared/Transfer/DownloadMessageTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/DownloadMessageTransfer.razor.cs
@@ -71,7 +71,7 @@ public partial class DownloadMessageTransfer
             return;
         }
 
-        await FileSaverService.UnregisterServiceWorkerAsync();
+        await FileSaverService.DeactivateServiceWorkerAsync();
         
         DecryptionInProgress = true;
 

--- a/Crypter.Web/Shared/Transfer/DownloadTransferBase.cs
+++ b/Crypter.Web/Shared/Transfer/DownloadTransferBase.cs
@@ -30,6 +30,7 @@ using Crypter.Common.Client.Interfaces.Services;
 using Crypter.Common.Client.Transfer;
 using Crypter.Common.Client.Transfer.Models;
 using Crypter.Common.Enums;
+using Crypter.Web.Services;
 using EasyMonads;
 using Microsoft.AspNetCore.Components;
 using Microsoft.IdentityModel.Tokens;
@@ -48,6 +49,8 @@ public class DownloadTransferBase : ComponentBase
     [Inject] protected ICryptoProvider CryptoProvider { get; init; } = null!;
     
     [Inject] protected ClientTransferSettings TransferSettings { get; init; } = null!;
+
+    [Inject] protected IFileSaverService FileSaverService { get; init; } = null!;
 
     [Parameter] public required string TransferHashId { get; set; }
 

--- a/Crypter.Web/Shared/Transfer/UploadFileTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/UploadFileTransfer.razor.cs
@@ -104,7 +104,7 @@ public partial class UploadFileTransfer : IDisposable
         EncryptionInProgress = true;
         ErrorMessage = string.Empty;
 
-        await FileSaverService.UnregisterServiceWorkerAsync();
+        await FileSaverService.DeactivateServiceWorkerAsync();
         
         await SetProgressMessageAsync("Encrypting file");
 

--- a/Crypter.Web/Shared/Transfer/UploadFileTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/UploadFileTransfer.razor.cs
@@ -104,6 +104,8 @@ public partial class UploadFileTransfer : IDisposable
         EncryptionInProgress = true;
         ErrorMessage = string.Empty;
 
+        await FileSaverService.UnregisterServiceWorkerAsync();
+        
         await SetProgressMessageAsync("Encrypting file");
 
         UploadFileHandler fileUploader = TransferHandlerFactory.CreateUploadFileHandler(FileStreamOpener,

--- a/Crypter.Web/Shared/Transfer/UploadMessageTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/UploadMessageTransfer.razor.cs
@@ -37,6 +37,8 @@ public partial class UploadMessageTransfer : IDisposable
 
     protected async Task OnEncryptClicked()
     {
+        await FileSaverService.UnregisterServiceWorkerAsync();
+        
         EncryptionInProgress = true;
         ErrorMessage = string.Empty;
 

--- a/Crypter.Web/Shared/Transfer/UploadMessageTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/UploadMessageTransfer.razor.cs
@@ -37,7 +37,7 @@ public partial class UploadMessageTransfer : IDisposable
 
     protected async Task OnEncryptClicked()
     {
-        await FileSaverService.UnregisterServiceWorkerAsync();
+        await FileSaverService.DeactivateServiceWorkerAsync();
         
         EncryptionInProgress = true;
         ErrorMessage = string.Empty;

--- a/Crypter.Web/Shared/Transfer/UploadTransferBase.cs
+++ b/Crypter.Web/Shared/Transfer/UploadTransferBase.cs
@@ -33,6 +33,7 @@ using Crypter.Common.Client.Transfer.Handlers.Base;
 using Crypter.Common.Client.Transfer.Models;
 using Crypter.Common.Contracts.Features.Transfer;
 using Crypter.Common.Enums;
+using Crypter.Web.Services;
 using Crypter.Web.Shared.Modal;
 using EasyMonads;
 using Microsoft.AspNetCore.Components;
@@ -51,6 +52,8 @@ public class UploadTransferBase : ComponentBase
     [Inject] protected ClientTransferSettings UploadSettings { get; init; } = null!;
 
     [Inject] protected TransferHandlerFactory TransferHandlerFactory { get; init; } = null!;
+
+    [Inject] protected IFileSaverService FileSaverService { get; init; } = null!;
 
     [Parameter] public Maybe<string> RecipientUsername { get; set; }
 

--- a/Crypter.Web/package.json
+++ b/Crypter.Web/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "buildFunctions": "vite build --config vite.functions.config.js",
     "buildFileSaver": "vite build --config vite.fileSaver.config.js",
-    "buildServiceWorker": "vite build --config vite.serviceWorker.config.js"
+    "buildServiceWorker": "vite build --config vite.serviceWorker.config.js",
+    "buildServiceWorkerNoOp": "vite build --config vite.serviceWorker.noOp.config.js"
   },
   "devDependencies": {
     "path": "^0.12.7",

--- a/Crypter.Web/vite.serviceWorker.noOp.config.js
+++ b/Crypter.Web/vite.serviceWorker.noOp.config.js
@@ -1,0 +1,16 @@
+import path from 'path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+    build: {
+        target: 'esnext',
+        minify: false,
+        lib: {
+            entry: path.resolve(__dirname, 'Npm/src/fileSaver/serviceWorker.noOp.ts'),
+            formats: ['es'],
+            fileName: 'serviceWorker.noOp',
+        },
+        outDir: path.resolve(__dirname, 'wwwroot/js/dist/serviceWorker.noOp'),
+        sourcemap: false,
+    }
+});


### PR DESCRIPTION
To work around the Chromium issues linked below, this PR ensures the "download" service worker is only present as a file is being downloaded.  Otherwise, a "no op" service worker is made active.

The reason for using a "no op" service worker, instead of simply unregistering the "download" service worker, is unregistration still requires the tab to be reloaded or a navigation to occur before the unregistered service worker stops working.  Replacing the service worker with one that does not have a "fetch" event handler works instantaneously and doesn't seem to interfere with file uploads.

Still not an ideal solution, as simultaneous upload and download will probably break, but the UI really doesn't lend to that usage anyway.

https://issues.chromium.org/issues/339788214
https://issues.chromium.org/issues/41360286