### PR TITLE
Stop deleting transfers with recipients immediately upon download

### DIFF
--- a/Crypter.Core/Features/Transfer/Commands/GetAnonymousFileCiphertextCommand.cs
+++ b/Crypter.Core/Features/Transfer/Commands/GetAnonymousFileCiphertextCommand.cs
@@ -54,9 +54,7 @@ internal class GetAnonymousFileCiphertextCommandHandler
     private readonly IHashIdService _hashIdService;
     private readonly IPublisher _publisher;
     private readonly ITransferRepository _transferRepository;
-    
-    private const bool DeleteFileUponReadCompletion = true;
-    
+
     public GetAnonymousFileCiphertextCommandHandler(
         ICryptoProvider cryptoProvider,
         DataContext dataContext,
@@ -84,7 +82,7 @@ internal class GetAnonymousFileCiphertextCommandHandler
         return await GetFileStreamAsync(itemId.Value, request.Proof)
             .DoRightAsync(async _ =>
             {
-                SuccessfulTransferDownloadEvent successfulTransferDownloadEvent = new SuccessfulTransferDownloadEvent(itemId.Value, TransferItemType.File, TransferUserType.Anonymous, null, !DeleteFileUponReadCompletion, DateTimeOffset.UtcNow);
+                SuccessfulTransferDownloadEvent successfulTransferDownloadEvent = new SuccessfulTransferDownloadEvent(itemId.Value, TransferItemType.File, TransferUserType.Anonymous, null, false, DateTimeOffset.UtcNow);
                 await _publisher.Publish(successfulTransferDownloadEvent, CancellationToken.None);
             })
             .DoLeftOrNeitherAsync(
@@ -124,7 +122,7 @@ internal class GetAnonymousFileCiphertextCommandHandler
         }
 
         return _transferRepository
-            .GetTransfer(itemId, TransferItemType.File, TransferUserType.Anonymous, DeleteFileUponReadCompletion)
+            .GetTransfer(itemId, TransferItemType.File, TransferUserType.Anonymous, true)
             .ToEither(DownloadTransferCiphertextError.NotFound);
     }
 }

--- a/Crypter.Core/Features/Transfer/Commands/GetAnonymousMessageCiphertextCommand.cs
+++ b/Crypter.Core/Features/Transfer/Commands/GetAnonymousMessageCiphertextCommand.cs
@@ -54,8 +54,6 @@ internal class GetAnonymousMessageCiphertextCommandHandler
     private readonly IHashIdService _hashIdService;
     private readonly IPublisher _publisher;
     private readonly ITransferRepository _transferRepository;
-
-    private const bool DeleteFileUponReadCompletion = true;
     
     public GetAnonymousMessageCiphertextCommandHandler(
         ICryptoProvider cryptoProvider,
@@ -84,7 +82,7 @@ internal class GetAnonymousMessageCiphertextCommandHandler
         return await GetFileStreamAsync(itemId.Value, request.Proof)
             .DoRightAsync(async _ =>
             {
-                SuccessfulTransferDownloadEvent downloadEvent = new SuccessfulTransferDownloadEvent(itemId.Value, TransferItemType.Message, TransferUserType.Anonymous, null, !DeleteFileUponReadCompletion, DateTimeOffset.UtcNow);
+                SuccessfulTransferDownloadEvent downloadEvent = new SuccessfulTransferDownloadEvent(itemId.Value, TransferItemType.Message, TransferUserType.Anonymous, null, false, DateTimeOffset.UtcNow);
                 await _publisher.Publish(downloadEvent, CancellationToken.None);
             })
             .DoLeftOrNeitherAsync(
@@ -124,7 +122,7 @@ internal class GetAnonymousMessageCiphertextCommandHandler
         }
         
         return _transferRepository
-            .GetTransfer(itemId, TransferItemType.Message, TransferUserType.Anonymous, DeleteFileUponReadCompletion)
+            .GetTransfer(itemId, TransferItemType.Message, TransferUserType.Anonymous, true)
             .ToEither(DownloadTransferCiphertextError.NotFound);
     }
 }

--- a/Crypter.Core/Features/Transfer/Commands/GetUserFileCiphertextCommand.cs
+++ b/Crypter.Core/Features/Transfer/Commands/GetUserFileCiphertextCommand.cs
@@ -87,7 +87,7 @@ internal class GetUserFileCiphertextCommandHandler
         return await GetFileStreamAsync(itemId.Value, nullableRequesterUserId, request.Proof)
             .DoRightAsync(async _ =>
             {
-                SuccessfulTransferDownloadEvent downloadEvent = new SuccessfulTransferDownloadEvent(itemId.Value, TransferItemType.File, TransferUserType.User, nullableRequesterUserId, !_transferHasRecipient, DateTimeOffset.UtcNow);
+                SuccessfulTransferDownloadEvent downloadEvent = new SuccessfulTransferDownloadEvent(itemId.Value, TransferItemType.File, TransferUserType.User, nullableRequesterUserId, _transferHasRecipient, DateTimeOffset.UtcNow);
                 await _publisher.Publish(downloadEvent, CancellationToken.None);
             })
             .DoLeftOrNeitherAsync(
@@ -127,7 +127,7 @@ internal class GetUserFileCiphertextCommandHandler
             return DownloadTransferCiphertextError.InvalidRecipientProof;
         }
 
-        _transferHasRecipient = !databaseData.RecipientId.HasValue;
+        _transferHasRecipient = databaseData.RecipientId.HasValue;
         return _transferRepository
             .GetTransfer(itemId, TransferItemType.File, TransferUserType.User, !_transferHasRecipient)
             .ToEither(DownloadTransferCiphertextError.NotFound);

--- a/Crypter.Core/Features/Transfer/Commands/GetUserMessageCiphertextCommand.cs
+++ b/Crypter.Core/Features/Transfer/Commands/GetUserMessageCiphertextCommand.cs
@@ -87,7 +87,7 @@ internal class GetUserMessageCiphertextCommandHandler
         return await GetFileStreamAsync(itemId.Value, nullableRequesterUserId, request.Proof)
             .DoRightAsync(async _ =>
             {
-                SuccessfulTransferDownloadEvent downloadEvent = new SuccessfulTransferDownloadEvent(itemId.Value, TransferItemType.Message, TransferUserType.User, nullableRequesterUserId, !_transferHasRecipient, DateTimeOffset.UtcNow);
+                SuccessfulTransferDownloadEvent downloadEvent = new SuccessfulTransferDownloadEvent(itemId.Value, TransferItemType.Message, TransferUserType.User, nullableRequesterUserId, _transferHasRecipient, DateTimeOffset.UtcNow);
                 await _publisher.Publish(downloadEvent, CancellationToken.None);
             })
             .DoLeftOrNeitherAsync(
@@ -127,7 +127,7 @@ internal class GetUserMessageCiphertextCommandHandler
             return DownloadTransferCiphertextError.InvalidRecipientProof;
         }
         
-        _transferHasRecipient = !databaseData.RecipientId.HasValue;
+        _transferHasRecipient = databaseData.RecipientId.HasValue;
         return _transferRepository
             .GetTransfer(itemId, TransferItemType.Message, TransferUserType.User, !_transferHasRecipient)
             .ToEither(DownloadTransferCiphertextError.NotFound);


### PR DESCRIPTION
Do not immediately delete a downloaded transfer when the transfer has a defined recipient.  The transfer should only be deleted upon expiration.