### PR TITLE
Improve the multipart upload algorithm

### DIFF
--- a/Crypter.Common.Client/Transfer/Handlers/Base/UploadHandler.cs
+++ b/Crypter.Common.Client/Transfer/Handlers/Base/UploadHandler.cs
@@ -53,8 +53,7 @@ public class UploadHandler : IUserUploadHandler
     
     protected Maybe<byte[]> RecipientPublicKey = Maybe<byte[]>.None;
 
-    protected UploadHandler(ICrypterApiClient crypterApiClient, ICryptoProvider cryptoProvider,
-        ClientTransferSettings clientTransferSettings)
+    protected UploadHandler(ICrypterApiClient crypterApiClient, ICryptoProvider cryptoProvider, ClientTransferSettings clientTransferSettings)
     {
         CrypterApiClient = crypterApiClient;
         CryptoProvider = cryptoProvider;

--- a/Crypter.Common.Client/Transfer/Handlers/UploadMessageHandler.cs
+++ b/Crypter.Common.Client/Transfer/Handlers/UploadMessageHandler.cs
@@ -46,11 +46,9 @@ public class UploadMessageHandler : UploadHandler
     private int _messageSize;
     private bool _transferInfoSet;
 
-    public UploadMessageHandler(ICrypterApiClient crypterApiClient, ICryptoProvider cryptoProvider,
-        ClientTransferSettings clientTransferSettings)
+    public UploadMessageHandler(ICrypterApiClient crypterApiClient, ICryptoProvider cryptoProvider, ClientTransferSettings clientTransferSettings)
         : base(crypterApiClient, cryptoProvider, clientTransferSettings)
-    {
-    }
+    { }
 
     internal void SetTransferInfo(string messageSubject, string messageBody, int expirationHours)
     {

--- a/Crypter.Common.Client/Transfer/Models/ClientTransferSettings.cs
+++ b/Crypter.Common.Client/Transfer/Models/ClientTransferSettings.cs
@@ -59,6 +59,11 @@ public class ClientTransferSettings
     public int MaximumMultipartParallelism { get; init; }
     
     /// <summary>
+    /// Set the number of seconds the adaptive multipart upload algorithm will target for individual upload requests.
+    /// </summary>
+    public int TargetMultipartUploadMilliseconds { get; init; }
+    
+    /// <summary>
     /// Set the number of bytes of plaintext to read at one time when encrypting a file or message.
     /// </summary>
     public int MaxReadSize { get; init; }

--- a/Crypter.Common.Client/Transfer/TransferHandlerFactory.cs
+++ b/Crypter.Common.Client/Transfer/TransferHandlerFactory.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2023 Crypter File Transfer
+ * Copyright (C) 2024 Crypter File Transfer
  *
  * This file is part of the Crypter file transfer project.
  *
@@ -51,34 +51,30 @@ public class TransferHandlerFactory
         _clientTransferSettings = clientTransferSettings;
     }
 
-    public UploadFileHandler CreateUploadFileHandler(Func<Stream> fileStreamOpener, string fileName, long fileSize,
-        string fileContentType, int expirationHours)
+    public UploadFileHandler CreateUploadFileHandler(Func<Stream> fileStreamOpener, string fileName, long fileSize, string fileContentType, int expirationHours)
     {
-        var handler = new UploadFileHandler(_crypterApiClient, _cryptoProvider, _clientTransferSettings);
+        UploadFileHandler handler = new UploadFileHandler(_crypterApiClient, _cryptoProvider, _clientTransferSettings);
         handler.SetTransferInfo(fileStreamOpener, fileName, fileSize, fileContentType, expirationHours);
         return handler;
     }
 
-    public UploadMessageHandler CreateUploadMessageHandler(string messageSubject, string messageBody,
-        int expirationHours)
+    public UploadMessageHandler CreateUploadMessageHandler(string messageSubject, string messageBody, int expirationHours)
     {
-        var handler = new UploadMessageHandler(_crypterApiClient, _cryptoProvider, _clientTransferSettings);
+        UploadMessageHandler handler = new UploadMessageHandler(_crypterApiClient, _cryptoProvider, _clientTransferSettings);
         handler.SetTransferInfo(messageSubject, messageBody, expirationHours);
         return handler;
     }
 
     public DownloadFileHandler CreateDownloadFileHandler(string hashId, TransferUserType userType)
     {
-        var handler =
-            new DownloadFileHandler(_crypterApiClient, _cryptoProvider, _userSessionService, _clientTransferSettings);
+        DownloadFileHandler handler = new DownloadFileHandler(_crypterApiClient, _cryptoProvider, _userSessionService, _clientTransferSettings);
         handler.SetTransferInfo(hashId, userType);
         return handler;
     }
 
     public DownloadMessageHandler CreateDownloadMessageHandler(string hashId, TransferUserType userType)
     {
-        var handler =
-            new DownloadMessageHandler(_crypterApiClient, _cryptoProvider, _userSessionService, _clientTransferSettings);
+        DownloadMessageHandler handler = new DownloadMessageHandler(_crypterApiClient, _cryptoProvider, _userSessionService, _clientTransferSettings);
         handler.SetTransferInfo(hashId, userType);
         return handler;
     }

--- a/Crypter.Web/wwwroot/appsettings.json
+++ b/Crypter.Web/wwwroot/appsettings.json
@@ -8,8 +8,15 @@
       "MaximumMultipartUploadSizeMB": 250,
       "MaximumMultipartReadBlocks": 120,
       "InitialMultipartReadBlocks": 10,
-      "MaximumMultipartParallelism": 1,
+      "MaximumMultipartParallelism": 2,
+      "TargetMultipartUploadMilliseconds": 1000,
       "MaxReadSize": 32704,
       "PadSize": 64
+   },
+   "Logging": {
+      "LogLevel": {
+         "Default": "Warning",
+         "Microsoft.AspNetCore": "Warning"
+      }
    }
 }


### PR DESCRIPTION
Calculate the optimum number of blocks per request based on how long it took the last request to complete.  Instead of increasing the number of block per request at an incremental rate until the configured maximum is reached.

Increase the maximum number of parallel requests from 1 to 2, which results in much faster uploads for faster connections.