### PR TITLE
Remove 'UploadNewKeys' from LoginResponse

### DIFF
--- a/Crypter.Common.Client/Crypter.Common.Client.csproj
+++ b/Crypter.Common.Client/Crypter.Common.Client.csproj
@@ -13,4 +13,8 @@
       <ProjectReference Include="..\Crypter.Crypto.Common\Crypter.Crypto.Common.csproj" />
    </ItemGroup>
 
+   <ItemGroup>
+     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+   </ItemGroup>
+
 </Project>

--- a/Crypter.Common.Client/Events/EmitRecoveryKeyEventArgs.cs
+++ b/Crypter.Common.Client/Events/EmitRecoveryKeyEventArgs.cs
@@ -28,11 +28,11 @@ using Crypter.Common.Client.Models;
 
 namespace Crypter.Common.Client.Events;
 
-public sealed class RecoveryKeyCreatedEventArgs
+public sealed class EmitRecoveryKeyEventArgs
 {
     public RecoveryKey RecoveryKey { get; }
 
-    public RecoveryKeyCreatedEventArgs(RecoveryKey recoveryKey)
+    public EmitRecoveryKeyEventArgs(RecoveryKey recoveryKey)
     {
         RecoveryKey = recoveryKey;
     }

--- a/Crypter.Common.Client/Events/RecoveryKeyCreatedEventArgs.cs
+++ b/Crypter.Common.Client/Events/RecoveryKeyCreatedEventArgs.cs
@@ -1,3 +1,29 @@
+/*
+ * Copyright (C) 2025 Crypter File Transfer
+ *
+ * This file is part of the Crypter file transfer project.
+ *
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ *
+ * Contact the current copyright holder to discuss commercial license options.
+ */
+
 using Crypter.Common.Client.Models;
 
 namespace Crypter.Common.Client.Events;

--- a/Crypter.Common.Client/Events/RecoveryKeyCreatedEventArgs.cs
+++ b/Crypter.Common.Client/Events/RecoveryKeyCreatedEventArgs.cs
@@ -1,0 +1,13 @@
+using Crypter.Common.Client.Models;
+
+namespace Crypter.Common.Client.Events;
+
+public sealed class RecoveryKeyCreatedEventArgs
+{
+    public RecoveryKey RecoveryKey { get; }
+
+    public RecoveryKeyCreatedEventArgs(RecoveryKey recoveryKey)
+    {
+        RecoveryKey = recoveryKey;
+    }
+}

--- a/Crypter.Common.Client/Events/UserLoggedInEventArgs.cs
+++ b/Crypter.Common.Client/Events/UserLoggedInEventArgs.cs
@@ -36,17 +36,14 @@ public class UserLoggedInEventArgs : EventArgs
     public Password Password { get; init; }
     public VersionedPassword VersionedPassword { get; init; }
     public bool RememberUser { get; init; }
-    public bool UploadNewKeys { get; init; }
     public bool ShowRecoveryKeyModal { get; init; }
 
-    public UserLoggedInEventArgs(Username username, Password password, VersionedPassword versionedPassword,
-        bool rememberUser, bool uploadNewKeys, bool showRecoveryKeyModal)
+    public UserLoggedInEventArgs(Username username, Password password, VersionedPassword versionedPassword, bool rememberUser, bool showRecoveryKeyModal)
     {
         Username = username;
         Password = password;
         VersionedPassword = versionedPassword;
         RememberUser = rememberUser;
-        UploadNewKeys = uploadNewKeys;
         ShowRecoveryKeyModal = showRecoveryKeyModal;
     }
 }

--- a/Crypter.Common.Client/Interfaces/Services/IEventfulUserKeysService.cs
+++ b/Crypter.Common.Client/Interfaces/Services/IEventfulUserKeysService.cs
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Crypter File Transfer
+ *
+ * This file is part of the Crypter file transfer project.
+ *
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ *
+ * Contact the current copyright holder to discuss commercial license options.
+ */
+
+using System;
+using Crypter.Common.Client.Events;
+
+namespace Crypter.Common.Client.Interfaces.Services;
+
+public interface IEventfulUserKeysService
+{
+    event EventHandler<EmitRecoveryKeyEventArgs> EmitRecoveryKeyEventHandler;
+}

--- a/Crypter.Common.Client/Interfaces/Services/IEventfulUserKeysService.cs
+++ b/Crypter.Common.Client/Interfaces/Services/IEventfulUserKeysService.cs
@@ -32,6 +32,4 @@ namespace Crypter.Common.Client.Interfaces.Services;
 public interface IEventfulUserKeysService
 {
     event EventHandler<EmitRecoveryKeyEventArgs> EmitRecoveryKeyEventHandler;
-    event EventHandler PrepareUserKeysBeginEventHandler;
-    event EventHandler PrepareUserKeysEndEventHandler;
 }

--- a/Crypter.Common.Client/Interfaces/Services/IEventfulUserKeysService.cs
+++ b/Crypter.Common.Client/Interfaces/Services/IEventfulUserKeysService.cs
@@ -32,4 +32,6 @@ namespace Crypter.Common.Client.Interfaces.Services;
 public interface IEventfulUserKeysService
 {
     event EventHandler<EmitRecoveryKeyEventArgs> EmitRecoveryKeyEventHandler;
+    event EventHandler PrepareUserKeysBeginEventHandler;
+    event EventHandler PrepareUserKeysEndEventHandler;
 }

--- a/Crypter.Common.Client/Interfaces/Services/IUserKeysService.cs
+++ b/Crypter.Common.Client/Interfaces/Services/IUserKeysService.cs
@@ -24,10 +24,8 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System.Threading.Tasks;
-using Crypter.Common.Client.Models;
-using Crypter.Common.Contracts.Features.UserAuthentication;
-using Crypter.Common.Primitives;
+using System;
+using Crypter.Common.Client.Events;
 using EasyMonads;
 
 namespace Crypter.Common.Client.Interfaces.Services;
@@ -36,10 +34,5 @@ public interface IUserKeysService
 {
     Maybe<byte[]> MasterKey { get; }
     Maybe<byte[]> PrivateKey { get; }
-
-    Task DownloadExistingKeysAsync(Username username, Password password, bool trustDevice);
-    Task DownloadExistingKeysAsync(byte[] credentialKey, bool trustDevice);
-    
-    Task<Maybe<RecoveryKey>> UploadNewKeysAsync(Username username, Password password, VersionedPassword versionedPassword, bool trustDevice);
-    Task<Maybe<RecoveryKey>> UploadNewKeysAsync(VersionedPassword versionedPassword, byte[] credentialKey, bool trustDevice);
+    event EventHandler<RecoveryKeyCreatedEventArgs> RecoveryKeyCreatedEventHandler;
 }

--- a/Crypter.Common.Client/Interfaces/Services/IUserKeysService.cs
+++ b/Crypter.Common.Client/Interfaces/Services/IUserKeysService.cs
@@ -34,5 +34,5 @@ public interface IUserKeysService
 {
     Maybe<byte[]> MasterKey { get; }
     Maybe<byte[]> PrivateKey { get; }
-    event EventHandler<RecoveryKeyCreatedEventArgs> RecoveryKeyCreatedEventHandler;
+    event EventHandler<EmitRecoveryKeyEventArgs> EmitRecoveryKeyEventHandler;
 }

--- a/Crypter.Common.Client/Interfaces/Services/IUserKeysService.cs
+++ b/Crypter.Common.Client/Interfaces/Services/IUserKeysService.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2023 Crypter File Transfer
+ * Copyright (C) 2025 Crypter File Transfer
  *
  * This file is part of the Crypter file transfer project.
  *
@@ -24,8 +24,10 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System;
-using Crypter.Common.Client.Events;
+using System.Threading.Tasks;
+using Crypter.Common.Client.Models;
+using Crypter.Common.Contracts.Features.UserAuthentication;
+using Crypter.Common.Primitives;
 using EasyMonads;
 
 namespace Crypter.Common.Client.Interfaces.Services;
@@ -34,5 +36,21 @@ public interface IUserKeysService
 {
     Maybe<byte[]> MasterKey { get; }
     Maybe<byte[]> PrivateKey { get; }
-    event EventHandler<EmitRecoveryKeyEventArgs> EmitRecoveryKeyEventHandler;
+    
+    /// <summary>
+    /// Derive a recovery key from the provided parameters.
+    /// </summary>
+    /// <param name="masterKey"></param>
+    /// <param name="username"></param>
+    /// <param name="password">A valid, plaintext password.</param>
+    /// <returns></returns>
+    Task<Maybe<RecoveryKey>> DeriveRecoveryKeyAsync(byte[] masterKey, Username username, Password password);
+
+    /// <summary>
+    /// Derive a recovery key from the provided parameters.
+    /// </summary>
+    /// <param name="masterKey"></param>
+    /// <param name="versionedPassword">A hashed password.</param>
+    /// <returns></returns>
+    Task<Maybe<RecoveryKey>> DeriveRecoveryKeyAsync(byte[] masterKey, VersionedPassword versionedPassword);
 }

--- a/Crypter.Common.Client/Interfaces/Services/IUserRecoveryService.cs
+++ b/Crypter.Common.Client/Interfaces/Services/IUserRecoveryService.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2024 Crypter File Transfer
+ * Copyright (C) 2025 Crypter File Transfer
  *
  * This file is part of the Crypter file transfer project.
  *
@@ -27,7 +27,6 @@
 using System.Threading.Tasks;
 using Crypter.Common.Client.Models;
 using Crypter.Common.Contracts.Features.AccountRecovery.SubmitRecovery;
-using Crypter.Common.Contracts.Features.UserAuthentication;
 using Crypter.Common.Primitives;
 using EasyMonads;
 
@@ -35,23 +34,6 @@ namespace Crypter.Common.Client.Interfaces.Services;
 
 public interface IUserRecoveryService
 {
-    /// <summary>
-    /// Derive a recovery key from the provided parameters.
-    /// </summary>
-    /// <param name="masterKey"></param>
-    /// <param name="username"></param>
-    /// <param name="password">A valid, plaintext password.</param>
-    /// <returns></returns>
-    Task<Maybe<RecoveryKey>> DeriveRecoveryKeyAsync(byte[] masterKey, Username username, Password password);
-
-    /// <summary>
-    /// Derive a recovery key from the provided parameters.
-    /// </summary>
-    /// <param name="masterKey"></param>
-    /// <param name="versionedPassword">A hashed password.</param>
-    /// <returns></returns>
-    Task<Maybe<RecoveryKey>> DeriveRecoveryKeyAsync(byte[] masterKey, VersionedPassword versionedPassword);
-
     /// <summary>
     /// Request an account recovery email.
     /// The email, if received, will contain a temporary link to proceed with account recovery.

--- a/Crypter.Common.Client/Repositories/MemoryUserSessionRepository.cs
+++ b/Crypter.Common.Client/Repositories/MemoryUserSessionRepository.cs
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 Crypter File Transfer
+ *
+ * This file is part of the Crypter file transfer project.
+ *
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ *
+ * Contact the current copyright holder to discuss commercial license options.
+ */
+
+using System.Threading.Tasks;
+using Crypter.Common.Client.Interfaces.Repositories;
+using Crypter.Common.Client.Models;
+using EasyMonads;
+
+namespace Crypter.Common.Client.Repositories;
+
+public class MemoryUserSessionRepository : IUserSessionRepository
+{
+    Maybe<UserSession> _userSession;
+
+    public MemoryUserSessionRepository()
+    {
+        _userSession = Maybe<UserSession>.None;
+    }
+    
+    public Task<Maybe<UserSession>> GetUserSessionAsync()
+    {
+        return _userSession.AsTask();
+    }
+
+    public Task StoreUserSessionAsync(UserSession userSession, bool rememberUser)
+    {
+        _userSession = userSession;
+        return Task.CompletedTask;
+    }
+}

--- a/Crypter.Common.Client/Services/EventfulUserKeysService.cs
+++ b/Crypter.Common.Client/Services/EventfulUserKeysService.cs
@@ -39,6 +39,8 @@ public sealed class EventfulUserKeysService : UserKeysService, IEventfulUserKeys
 {
     private readonly IUserSessionService _userSessionService;
     private EventHandler<EmitRecoveryKeyEventArgs>? _emitRecoveryKeyEventHandler;
+    private event EventHandler? _prepareUserKeysBeginEventHandler;
+    private event EventHandler? _prepareUserKeysEndEventHandler;
     
     public EventfulUserKeysService(ICrypterApiClient crypterApiClient, ICryptoProvider cryptoProvider, IUserPasswordService userPasswordService, IUserKeysRepository userKeysRepository, IUserSessionService userSessionService)
         : base(crypterApiClient, cryptoProvider, userPasswordService, userKeysRepository)
@@ -62,6 +64,7 @@ public sealed class EventfulUserKeysService : UserKeysService, IEventfulUserKeys
     private async void HandleUserLoginAsync(object? _, UserLoggedInEventArgs args)
     {
         await UserPasswordService.DeriveUserCredentialKeyAsync(args.Username, args.Password, UserPasswordService.CurrentPasswordVersion)
+            .IfSomeAsync(_ => HandlePrepareUserKeysBeginEvent())
             .BindAsync(async credentialKey => await GetOrCreateMasterKeyAsync(args.VersionedPassword, credentialKey)
                 .BindAsync(x => new { CredentialKey = credentialKey, x.MasterKey, x.NewRecoveryKey }))
             .BindAsync(async carryData => await GetOrCreateKeyPairAsync(carryData.MasterKey)
@@ -69,6 +72,7 @@ public sealed class EventfulUserKeysService : UserKeysService, IEventfulUserKeys
             .IfSomeAsync(async carryData =>
             {
                 await StoreSecretKeysAsync(carryData.MasterKey, carryData.PrivateKey, args.RememberUser);
+                HandlePrepareUserKeysEndEvent();
                 await carryData.NewRecoveryKey
                     .IfSome(HandleEmitRecoveryKeyEvent)
                     .IfNoneAsync(async () =>
@@ -85,12 +89,34 @@ public sealed class EventfulUserKeysService : UserKeysService, IEventfulUserKeys
     private void HandleEmitRecoveryKeyEvent(RecoveryKey recoveryKey) =>
         _emitRecoveryKeyEventHandler?.Invoke(this, new EmitRecoveryKeyEventArgs(recoveryKey));
     
+    private void HandlePrepareUserKeysBeginEvent() =>
+        _prepareUserKeysBeginEventHandler?.Invoke(this, EventArgs.Empty);
+    
+    private void HandlePrepareUserKeysEndEvent() =>
+        _prepareUserKeysEndEventHandler?.Invoke(this, EventArgs.Empty);
+    
     public event EventHandler<EmitRecoveryKeyEventArgs> EmitRecoveryKeyEventHandler
     {
         add => _emitRecoveryKeyEventHandler = 
             (EventHandler<EmitRecoveryKeyEventArgs>)Delegate.Combine(_emitRecoveryKeyEventHandler, value);
         remove => _emitRecoveryKeyEventHandler =
             (EventHandler<EmitRecoveryKeyEventArgs>?)Delegate.Remove(_emitRecoveryKeyEventHandler, value);
+    }
+    
+    public event EventHandler PrepareUserKeysBeginEventHandler
+    {
+        add => _prepareUserKeysBeginEventHandler = 
+            (EventHandler)Delegate.Combine(_prepareUserKeysBeginEventHandler, value);
+        remove => _prepareUserKeysBeginEventHandler =
+            (EventHandler?)Delegate.Remove(_prepareUserKeysBeginEventHandler, value);
+    }
+    
+    public event EventHandler PrepareUserKeysEndEventHandler
+    {
+        add => _prepareUserKeysEndEventHandler = 
+            (EventHandler)Delegate.Combine(_prepareUserKeysEndEventHandler, value);
+        remove => _prepareUserKeysEndEventHandler =
+            (EventHandler?)Delegate.Remove(_prepareUserKeysEndEventHandler, value);
     }
     
     private void Recycle(object? _, EventArgs __)

--- a/Crypter.Common.Client/Services/EventfulUserKeysService.cs
+++ b/Crypter.Common.Client/Services/EventfulUserKeysService.cs
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2025 Crypter File Transfer
+ *
+ * This file is part of the Crypter file transfer project.
+ *
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ *
+ * Contact the current copyright holder to discuss commercial license options.
+ */
+
+using System;
+using Crypter.Common.Client.Events;
+using Crypter.Common.Client.Interfaces.HttpClients;
+using Crypter.Common.Client.Interfaces.Repositories;
+using Crypter.Common.Client.Interfaces.Services;
+using Crypter.Common.Client.Models;
+using Crypter.Crypto.Common;
+using EasyMonads;
+
+namespace Crypter.Common.Client.Services;
+
+public sealed class EventfulUserKeysService : UserKeysService, IEventfulUserKeysService, IDisposable
+{
+    private readonly IUserSessionService _userSessionService;
+    private EventHandler<EmitRecoveryKeyEventArgs>? _emitRecoveryKeyEventHandler;
+    
+    public EventfulUserKeysService(ICrypterApiClient crypterApiClient, ICryptoProvider cryptoProvider, IUserPasswordService userPasswordService, IUserKeysRepository userKeysRepository, IUserSessionService userSessionService)
+        : base(crypterApiClient, cryptoProvider, userPasswordService, userKeysRepository)
+    {
+        _userSessionService = userSessionService;
+        
+        _userSessionService.ServiceInitializedEventHandler += InitializeAsync;
+        _userSessionService.UserLoggedInEventHandler += HandleUserLoginAsync;
+        _userSessionService.UserLoggedOutEventHandler += Recycle;
+    }
+    
+    private async void InitializeAsync(object? _, UserSessionServiceInitializedEventArgs args)
+    {
+        if (args.IsLoggedIn)
+        {
+            MasterKey = await UserKeysRepository.GetMasterKeyAsync();
+            PrivateKey = await UserKeysRepository.GetPrivateKeyAsync();
+        }
+    }
+    
+    private async void HandleUserLoginAsync(object? _, UserLoggedInEventArgs args)
+    {
+        await UserPasswordService.DeriveUserCredentialKeyAsync(args.Username, args.Password, UserPasswordService.CurrentPasswordVersion)
+            .BindAsync(async credentialKey => await GetOrCreateMasterKeyAsync(args.VersionedPassword, credentialKey)
+                .BindAsync(x => new { CredentialKey = credentialKey, x.MasterKey, x.NewRecoveryKey }))
+            .BindAsync(async carryData => await GetOrCreateKeyPairAsync(carryData.MasterKey)
+                .BindAsync(x => new { carryData.CredentialKey, carryData.MasterKey, x.PrivateKey, carryData.NewRecoveryKey }))
+            .IfSomeAsync(async carryData =>
+            {
+                await StoreSecretKeysAsync(carryData.MasterKey, carryData.PrivateKey, args.RememberUser);
+                await carryData.NewRecoveryKey
+                    .IfSome(HandleEmitRecoveryKeyEvent)
+                    .IfNoneAsync(async () =>
+                    {
+                        if (args.ShowRecoveryKeyModal)
+                        {
+                            await DeriveRecoveryKeyAsync(carryData.MasterKey, args.VersionedPassword)
+                                .IfSomeAsync(HandleEmitRecoveryKeyEvent);
+                        }
+                    });
+            });
+    }
+    
+    private void HandleEmitRecoveryKeyEvent(RecoveryKey recoveryKey) =>
+        _emitRecoveryKeyEventHandler?.Invoke(this, new EmitRecoveryKeyEventArgs(recoveryKey));
+    
+    public event EventHandler<EmitRecoveryKeyEventArgs> EmitRecoveryKeyEventHandler
+    {
+        add => _emitRecoveryKeyEventHandler = 
+            (EventHandler<EmitRecoveryKeyEventArgs>)Delegate.Combine(_emitRecoveryKeyEventHandler, value);
+        remove => _emitRecoveryKeyEventHandler =
+            (EventHandler<EmitRecoveryKeyEventArgs>?)Delegate.Remove(_emitRecoveryKeyEventHandler, value);
+    }
+    
+    private void Recycle(object? _, EventArgs __)
+    {
+        MasterKey = Maybe<byte[]>.None;
+        PrivateKey = Maybe<byte[]>.None;
+    }
+
+    public void Dispose()
+    {
+        _userSessionService.ServiceInitializedEventHandler -= InitializeAsync;
+        _userSessionService.UserLoggedInEventHandler -= HandleUserLoginAsync;
+        _userSessionService.UserLoggedOutEventHandler -= Recycle;
+    }
+}

--- a/Crypter.Common.Client/Services/UserKeysService.cs
+++ b/Crypter.Common.Client/Services/UserKeysService.cs
@@ -78,13 +78,13 @@ public class UserKeysService : IUserKeysService, IDisposable
     {
         await _userPasswordService.DeriveUserCredentialKeyAsync(args.Username, args.Password, _userPasswordService.CurrentPasswordVersion)
             .BindAsync(async credentialKey => await GetOrCreateMasterKeyAsync(args.VersionedPassword, credentialKey)
-                .BindAsync(x => new { CredentialKey = credentialKey, x.MasterKey, x.RecoveryKey }))
+                .BindAsync(x => new { CredentialKey = credentialKey, x.MasterKey, x.NewRecoveryKey }))
             .BindAsync(async carryData => await GetOrCreateKeyPairAsync(carryData.MasterKey)
-                .BindAsync(x => new { carryData.CredentialKey, carryData.MasterKey, x.PrivateKey, carryData.RecoveryKey }))
+                .BindAsync(x => new { carryData.CredentialKey, carryData.MasterKey, x.PrivateKey, carryData.NewRecoveryKey }))
             .IfSomeAsync(async carryData =>
             {
                 await StoreSecretKeysAsync(carryData.MasterKey, carryData.PrivateKey, args.RememberUser);
-                carryData.RecoveryKey.IfSome(HandleRecoveryKeyCreatedEvent);
+                carryData.NewRecoveryKey.IfSome(HandleRecoveryKeyCreatedEvent);
             });
     }
 
@@ -204,12 +204,12 @@ public class UserKeysService : IUserKeysService, IDisposable
     private sealed record GetOrCreateMasterKeyResult
     {
         public byte[] MasterKey { get; }
-        public Maybe<RecoveryKey> RecoveryKey { get; }
+        public Maybe<RecoveryKey> NewRecoveryKey { get; }
 
-        public GetOrCreateMasterKeyResult(byte[] masterKey, Maybe<RecoveryKey> recoveryKey)
+        public GetOrCreateMasterKeyResult(byte[] masterKey, Maybe<RecoveryKey> newRecoveryKey)
         {
             MasterKey = masterKey;
-            RecoveryKey = recoveryKey;
+            NewRecoveryKey = newRecoveryKey;
         }
     }
 

--- a/Crypter.Common.Client/Services/UserRecoveryService.cs
+++ b/Crypter.Common.Client/Services/UserRecoveryService.cs
@@ -43,8 +43,7 @@ public class UserRecoveryService : IUserRecoveryService
     private readonly ICryptoProvider _cryptoProvider;
     private readonly IUserPasswordService _userPasswordService;
 
-    public UserRecoveryService(ICrypterApiClient crypterApiClient, ICryptoProvider cryptoProvider,
-        IUserPasswordService userPasswordService)
+    public UserRecoveryService(ICrypterApiClient crypterApiClient, ICryptoProvider cryptoProvider, IUserPasswordService userPasswordService)
     {
         _crypterApiClient = crypterApiClient;
         _cryptoProvider = cryptoProvider;
@@ -62,8 +61,7 @@ public class UserRecoveryService : IUserRecoveryService
         Either<SubmitAccountRecoveryError, PasswordDerivatives> passwordDerivatives = await _userPasswordService
             .DeriveUserAuthenticationPasswordAsync(username, newPassword, _userPasswordService.CurrentPasswordVersion)
             .ToEitherAsync(SubmitAccountRecoveryError.PasswordHashFailure)
-            .MapAsync(async versionedPassword => await _userPasswordService.DeriveUserCredentialKeyAsync(username,
-                    newPassword, _userPasswordService.CurrentPasswordVersion)
+            .MapAsync(async versionedPassword => await _userPasswordService.DeriveUserCredentialKeyAsync(username, newPassword, _userPasswordService.CurrentPasswordVersion)
                 .ToEitherAsync(SubmitAccountRecoveryError.PasswordHashFailure)
                 .BindAsync<SubmitAccountRecoveryError, byte[], PasswordDerivatives>(credentialKey => new PasswordDerivatives
                 {

--- a/Crypter.Common.Client/Services/UserRecoveryService.cs
+++ b/Crypter.Common.Client/Services/UserRecoveryService.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2023 Crypter File Transfer
+ * Copyright (C) 2025 Crypter File Transfer
  *
  * This file is part of the Crypter file transfer project.
  *
@@ -29,7 +29,6 @@ using Crypter.Common.Client.Interfaces.HttpClients;
 using Crypter.Common.Client.Interfaces.Services;
 using Crypter.Common.Client.Models;
 using Crypter.Common.Contracts.Features.AccountRecovery.SubmitRecovery;
-using Crypter.Common.Contracts.Features.Keys;
 using Crypter.Common.Contracts.Features.UserAuthentication;
 using Crypter.Common.Primitives;
 using Crypter.Crypto.Common;
@@ -105,21 +104,6 @@ public class UserRecoveryService : IUserRecoveryService
                     .MapAsync<SubmitAccountRecoveryError, Unit, Maybe<RecoveryKey>>(_ => x.RecoveryArtifacts
                         .Select(y => y.NewRecoveryKey));
             });
-    }
-
-    public Task<Maybe<RecoveryKey>> DeriveRecoveryKeyAsync(byte[] masterKey, Username username, Password password)
-    {
-        return _userPasswordService
-            .DeriveUserAuthenticationPasswordAsync(username, password, _userPasswordService.CurrentPasswordVersion)
-            .BindAsync(versionedPassword => DeriveRecoveryKeyAsync(masterKey, versionedPassword));
-    }
-
-    public Task<Maybe<RecoveryKey>> DeriveRecoveryKeyAsync(byte[] masterKey, VersionedPassword versionedPassword)
-    {
-        GetMasterKeyRecoveryProofRequest request = new GetMasterKeyRecoveryProofRequest(versionedPassword.Password);
-        return _crypterApiClient.UserKey.GetMasterKeyRecoveryProofAsync(request)
-            .ToMaybeTask()
-            .MapAsync(x => new RecoveryKey(masterKey, x.Proof));
     }
     
     private struct PasswordDerivatives

--- a/Crypter.Common/Contracts/Features/UserAuthentication/Login/LoginResponse.cs
+++ b/Crypter.Common/Contracts/Features/UserAuthentication/Login/LoginResponse.cs
@@ -33,17 +33,14 @@ public class LoginResponse
     public string Username { get; init; }
     public string AuthenticationToken { get; init; }
     public string RefreshToken { get; init; }
-    public bool UploadNewKeys { get; init; }
     public bool ShowRecoveryKey { get; init; }
 
     [JsonConstructor]
-    public LoginResponse(string username, string authenticationToken, string refreshToken, bool uploadNewKeys,
-        bool showRecoveryKey)
+    public LoginResponse(string username, string authenticationToken, string refreshToken, bool showRecoveryKey)
     {
         Username = username;
         AuthenticationToken = authenticationToken;
         RefreshToken = refreshToken;
-        UploadNewKeys = uploadNewKeys;
         ShowRecoveryKey = showRecoveryKey;
     }
 }

--- a/Crypter.Core/Features/Keys/Queries/GetPrivateKeyQuery.cs
+++ b/Crypter.Core/Features/Keys/Queries/GetPrivateKeyQuery.cs
@@ -48,8 +48,7 @@ internal class GetPrivateKeyQueryHandler
         _dataContext = dataContext;
     }
     
-    public Task<Either<GetPrivateKeyError, GetPrivateKeyResponse>> Handle(GetPrivateKeyQuery request,
-        CancellationToken cancellationToken)
+    public Task<Either<GetPrivateKeyError, GetPrivateKeyResponse>> Handle(GetPrivateKeyQuery request, CancellationToken cancellationToken)
     {
         return Either<GetPrivateKeyError, GetPrivateKeyResponse>.FromRightNullableAsync(
             _dataContext.UserKeyPairs

--- a/Crypter.Test/Integration_Tests/UserRecovery_Tests/SubmitRecovery_Tests.cs
+++ b/Crypter.Test/Integration_Tests/UserRecovery_Tests/SubmitRecovery_Tests.cs
@@ -49,6 +49,7 @@ using EasyMonads;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 
 namespace Crypter.Test.Integration_Tests.UserRecovery_Tests;
@@ -116,7 +117,7 @@ internal class SubmitRecovery_Tests
 
             UserPasswordService userPasswordService = new UserPasswordService(_cryptoProvider!);
             IUserKeysRepository userKeysRepository = new MemoryKeysRepository();
-            UserKeysService userKeysService = new UserKeysService(_client, new DefaultCryptoProvider(), userPasswordService, userKeysRepository);
+            UserKeysService userKeysService = new UserKeysService(NullLogger<UserKeysService>.Instance, _client, new DefaultCryptoProvider(), userPasswordService, userKeysRepository);
             recoveryKey = await userKeysService.DeriveRecoveryKeyAsync(masterKey, registrationRequest.VersionedPassword);
             recoveryKey.IfNone(Assert.Fail);
         }
@@ -209,7 +210,7 @@ internal class SubmitRecovery_Tests
 
         UserPasswordService userPasswordService = new UserPasswordService(_cryptoProvider!);
         IUserKeysRepository userKeysRepository = new MemoryKeysRepository();
-        UserKeysService userKeysService = new UserKeysService(_client, new DefaultCryptoProvider(), userPasswordService, userKeysRepository);
+        UserKeysService userKeysService = new UserKeysService(NullLogger<UserKeysService>.Instance, _client, new DefaultCryptoProvider(), userPasswordService, userKeysRepository);
         Maybe<RecoveryKey> recoveryKeyResponse = await userKeysService.DeriveRecoveryKeyAsync(masterKey, registrationRequest.VersionedPassword);
 
         await recoveryKeyResponse

--- a/Crypter.Test/Integration_Tests/UserRecovery_Tests/SubmitRecovery_Tests.cs
+++ b/Crypter.Test/Integration_Tests/UserRecovery_Tests/SubmitRecovery_Tests.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2024 Crypter File Transfer
+ * Copyright (C) 2025 Crypter File Transfer
  *
  * This file is part of the Crypter file transfer project.
  *
@@ -24,13 +24,13 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Crypter.Common.Client.Interfaces.HttpClients;
 using Crypter.Common.Client.Interfaces.Repositories;
 using Crypter.Common.Client.Models;
+using Crypter.Common.Client.Repositories;
 using Crypter.Common.Client.Services;
 using Crypter.Common.Contracts.Features.AccountRecovery.RequestRecovery;
 using Crypter.Common.Contracts.Features.AccountRecovery.SubmitRecovery;
@@ -50,7 +50,6 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
-using UserRecoveryService = Crypter.Common.Client.Services.UserRecoveryService;
 
 namespace Crypter.Test.Integration_Tests.UserRecovery_Tests;
 
@@ -116,8 +115,9 @@ internal class SubmitRecovery_Tests
             Either<InsertMasterKeyError, Unit> _ = await _client!.UserKey.InsertMasterKeyAsync(insertMasterKeyRequest);
 
             UserPasswordService userPasswordService = new UserPasswordService(_cryptoProvider!);
-            UserRecoveryService userRecoveryService = new UserRecoveryService(_client, new DefaultCryptoProvider(), userPasswordService);
-            recoveryKey = await userRecoveryService.DeriveRecoveryKeyAsync(masterKey, registrationRequest.VersionedPassword);
+            IUserKeysRepository userKeysRepository = new MemoryKeysRepository();
+            UserKeysService userKeysService = new UserKeysService(_client, new DefaultCryptoProvider(), userPasswordService, userKeysRepository);
+            recoveryKey = await userKeysService.DeriveRecoveryKeyAsync(masterKey, registrationRequest.VersionedPassword);
             recoveryKey.IfNone(Assert.Fail);
         }
 
@@ -145,22 +145,16 @@ internal class SubmitRecovery_Tests
             .FirstAsync();
         
         string encodedRecoveryCode = UrlSafeEncoder.EncodeGuidUrlSafe(recoveryData.Code);
-        byte[] signedRecoveryData = Core.Features.AccountRecovery.Common.GenerateRecoverySignature(_cryptoProvider!, _knownKeyPair!.PrivateKey,
-            recoveryData.Code, Username.From(TestData.DefaultUsername));
+        byte[] signedRecoveryData = Core.Features.AccountRecovery.Common.GenerateRecoverySignature(_cryptoProvider!, _knownKeyPair!.PrivateKey, recoveryData.Code, Username.From(TestData.DefaultUsername));
         string encodedRecoverySignature = UrlSafeEncoder.EncodeBytesUrlSafe(signedRecoveryData);
 
-        VersionedPassword versionedPassword =
-            new VersionedPassword(Encoding.UTF8.GetBytes(TestData.DefaultPassword), 1);
+        VersionedPassword versionedPassword = new VersionedPassword(Encoding.UTF8.GetBytes(TestData.DefaultPassword), 1);
 
         AccountRecoverySubmission recoverySubmission = recoveryKey
-            .Bind<ReplacementMasterKeyInformation>(x => new ReplacementMasterKeyInformation(
-                x.Proof, [0x01], [0x02],
-                [0x03]))
+            .Bind<ReplacementMasterKeyInformation>(x => new ReplacementMasterKeyInformation(x.Proof, [0x01], [0x02], [0x03]))
             .Match(
-                none: new AccountRecoverySubmission(TestData.DefaultUsername, encodedRecoveryCode,
-                    encodedRecoverySignature, versionedPassword),
-                some: x => new AccountRecoverySubmission(TestData.DefaultUsername, encodedRecoveryCode,
-                    encodedRecoverySignature, versionedPassword, x));
+                none: new AccountRecoverySubmission(TestData.DefaultUsername, encodedRecoveryCode, encodedRecoverySignature, versionedPassword),
+                some: x => new AccountRecoverySubmission(TestData.DefaultUsername, encodedRecoveryCode, encodedRecoverySignature, versionedPassword, x));
 
         Either<SubmitAccountRecoveryError, Unit> result = await _client!.UserRecovery.SubmitRecoveryAsync(recoverySubmission);
         
@@ -174,10 +168,8 @@ internal class SubmitRecovery_Tests
     [Test]
     public async Task Submit_Recovery_Fails_When_Recovery_Code_Provided_With_Empty_New_Master_Key_Information()
     {
-        RegistrationRequest registrationRequest = TestData.GetRegistrationRequest(TestData.DefaultUsername,
-            TestData.DefaultPassword, TestData.DefaultEmailAdress);
-        Either<RegistrationError, Unit> registrationResult =
-            await _client!.UserAuthentication.RegisterAsync(registrationRequest);
+        RegistrationRequest registrationRequest = TestData.GetRegistrationRequest(TestData.DefaultUsername, TestData.DefaultPassword, TestData.DefaultEmailAdress);
+        Either<RegistrationError, Unit> registrationResult = await _client!.UserAuthentication.RegisterAsync(registrationRequest);
 
         // Allow the background service to "send" the verification email and save the email verification data
         await Task.Delay(5000);
@@ -194,20 +186,16 @@ internal class SubmitRecovery_Tests
                 verificationData.Code.ToByteArray());
         string encodedVerificationSignature = UrlSafeEncoder.EncodeBytesUrlSafe(signedVerificationCode);
 
-        VerifyEmailAddressRequest verificationRequest =
-            new VerifyEmailAddressRequest(encodedVerificationCode, encodedVerificationSignature);
-        Either<VerifyEmailAddressError, Unit> verificationResult =
-            await _client!.UserSetting.VerifyUserEmailAddressAsync(verificationRequest);
+        VerifyEmailAddressRequest verificationRequest = new VerifyEmailAddressRequest(encodedVerificationCode, encodedVerificationSignature);
+        Either<VerifyEmailAddressError, Unit> verificationResult = await _client!.UserSetting.VerifyUserEmailAddressAsync(verificationRequest);
 
         EmailAddress emailAddress = EmailAddress.From(TestData.DefaultEmailAdress);
-        Either<SendRecoveryEmailError, Unit> sendRecoveryEmailResult =
-            await _client!.UserRecovery.SendRecoveryEmailAsync(emailAddress);
+        Either<SendRecoveryEmailError, Unit> sendRecoveryEmailResult = await _client!.UserRecovery.SendRecoveryEmailAsync(emailAddress);
 
         // Allow the background service to "send" the recovery email and save the recovery data
         await Task.Delay(5000);
 
-        LoginRequest loginRequest =
-            TestData.GetLoginRequest(TestData.DefaultUsername, TestData.DefaultPassword);
+        LoginRequest loginRequest = TestData.GetLoginRequest(TestData.DefaultUsername, TestData.DefaultPassword);
         Either<LoginError, LoginResponse> loginResult = await _client!.UserAuthentication.LoginAsync(loginRequest);
 
         await loginResult.DoRightAsync(async loginResponse =>
@@ -216,16 +204,13 @@ internal class SubmitRecovery_Tests
             await _clientTokenRepository!.StoreRefreshTokenAsync(loginResponse.RefreshToken, TokenType.Session);
         });
 
-        (byte[] masterKey, InsertMasterKeyRequest insertMasterKeyRequest) =
-            TestData.GetInsertMasterKeyRequest(TestData.DefaultPassword);
-        Either<InsertMasterKeyError, Unit> _ =
-            await _client!.UserKey.InsertMasterKeyAsync(insertMasterKeyRequest);
+        (byte[] masterKey, InsertMasterKeyRequest insertMasterKeyRequest) = TestData.GetInsertMasterKeyRequest(TestData.DefaultPassword);
+        Either<InsertMasterKeyError, Unit> _ = await _client!.UserKey.InsertMasterKeyAsync(insertMasterKeyRequest);
 
         UserPasswordService userPasswordService = new UserPasswordService(_cryptoProvider!);
-        UserRecoveryService userRecoveryService =
-            new UserRecoveryService(_client, new DefaultCryptoProvider(), userPasswordService);
-        Maybe<RecoveryKey> recoveryKeyResponse =
-            await userRecoveryService.DeriveRecoveryKeyAsync(masterKey, registrationRequest.VersionedPassword);
+        IUserKeysRepository userKeysRepository = new MemoryKeysRepository();
+        UserKeysService userKeysService = new UserKeysService(_client, new DefaultCryptoProvider(), userPasswordService, userKeysRepository);
+        Maybe<RecoveryKey> recoveryKeyResponse = await userKeysService.DeriveRecoveryKeyAsync(masterKey, registrationRequest.VersionedPassword);
 
         await recoveryKeyResponse
             .IfNone(Assert.Fail)
@@ -240,11 +225,9 @@ internal class SubmitRecovery_Tests
                     recoveryData.Code, Username.From(TestData.DefaultUsername));
                 string encodedRecoverySignature = UrlSafeEncoder.EncodeBytesUrlSafe(signedRecoveryData);
 
-                VersionedPassword versionedPassword =
-                    new VersionedPassword(Encoding.UTF8.GetBytes(TestData.DefaultPassword), 1);
+                VersionedPassword versionedPassword = new VersionedPassword(Encoding.UTF8.GetBytes(TestData.DefaultPassword), 1);
 
-                ReplacementMasterKeyInformation replacementMasterKeyInformation =
-                    new ReplacementMasterKeyInformation(recoveryKey.Proof, [], [], []);
+                ReplacementMasterKeyInformation replacementMasterKeyInformation = new ReplacementMasterKeyInformation(recoveryKey.Proof, [], [], []);
 
                 AccountRecoverySubmission submission = new AccountRecoverySubmission(TestData.DefaultUsername, encodedRecoveryCode,
                     encodedRecoverySignature, versionedPassword, replacementMasterKeyInformation);

--- a/Crypter.Web/Client/Program.cs
+++ b/Crypter.Web/Client/Program.cs
@@ -49,12 +49,14 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 WebAssemblyHostBuilder builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 Console.WriteLine($"Environment: {builder.HostEnvironment.Environment}");
+builder.Logging.SetMinimumLevel(builder.Configuration.GetValue<LogLevel?>("LoggingConfiguration:MinimumLogLevel") ?? LogLevel.Information);
 
 builder.Services.AddSingleton(sp =>
 {
@@ -97,15 +99,17 @@ builder.Services
     .AddSingleton<IUserContactsService, UserContactsService>()
     .AddSingleton<IUserPasswordService, UserPasswordService>()
     .AddSingleton<IUserRecoveryService, UserRecoveryService>()
-    .AddSingleton<IEventfulUserKeysService, EventfulUserKeysService>()
-    .AddSingleton<IUserKeysService, UserKeysService>()
     .AddSingleton<IUserProfileSettingsService, UserProfileSettingsService>()
     .AddSingleton<IUserContactInfoSettingsService, UserContactInfoSettingsService>()
     .AddSingleton<IUserNotificationSettingsService, UserNotificationSettingsService>()
     .AddSingleton<IUserPrivacySettingsService, UserPrivacySettingsService>()
     .AddSingleton<IUserPasswordChangeService, UserPasswordChangeService>()
     .AddSingleton<TransferHandlerFactory>()
-    .AddSingleton<Func<ICrypterApiClient>>(sp => sp.GetRequiredService<ICrypterApiClient>);
+    .AddSingleton<Func<ICrypterApiClient>>(sp => sp.GetRequiredService<ICrypterApiClient>)
+
+    .AddSingleton<EventfulUserKeysService>()
+    .AddSingleton<IUserKeysService>(x => x.GetRequiredService<EventfulUserKeysService>())
+    .AddSingleton<IEventfulUserKeysService>(x => x.GetRequiredService<EventfulUserKeysService>());
 
 if (OperatingSystem.IsBrowser())
 {

--- a/Crypter.Web/Client/Program.cs
+++ b/Crypter.Web/Client/Program.cs
@@ -97,7 +97,6 @@ builder.Services
     .AddSingleton<IUserContactsService, UserContactsService>()
     .AddSingleton<IUserPasswordService, UserPasswordService>()
     .AddSingleton<IUserRecoveryService, UserRecoveryService>()
-    .AddSingleton<IEventfulUserKeysService, EventfulUserKeysService>()
     .AddSingleton<IUserKeysService, UserKeysService>()
     .AddSingleton<IUserProfileSettingsService, UserProfileSettingsService>()
     .AddSingleton<IUserContactInfoSettingsService, UserContactInfoSettingsService>()

--- a/Crypter.Web/Client/Program.cs
+++ b/Crypter.Web/Client/Program.cs
@@ -97,6 +97,7 @@ builder.Services
     .AddSingleton<IUserContactsService, UserContactsService>()
     .AddSingleton<IUserPasswordService, UserPasswordService>()
     .AddSingleton<IUserRecoveryService, UserRecoveryService>()
+    .AddSingleton<IEventfulUserKeysService, EventfulUserKeysService>()
     .AddSingleton<IUserKeysService, UserKeysService>()
     .AddSingleton<IUserProfileSettingsService, UserProfileSettingsService>()
     .AddSingleton<IUserContactInfoSettingsService, UserContactInfoSettingsService>()

--- a/Crypter.Web/Shared/MainLayout.razor.cs
+++ b/Crypter.Web/Shared/MainLayout.razor.cs
@@ -62,6 +62,8 @@ public class MainLayoutBase : LayoutComponentBase, IDisposable
     protected override async Task OnInitializedAsync()
     {
         EventfulUserKeysService.EmitRecoveryKeyEventHandler += HandleRecoveryKeyCreatedEvent;
+        EventfulUserKeysService.PrepareUserKeysBeginEventHandler += ShowUserKeysProgressModal;
+        EventfulUserKeysService.PrepareUserKeysEndEventHandler += CloseUserKeysProgressModal;
         UserPasswordService.PasswordHashBeginEventHandler += ShowPasswordHashingModal;
         UserPasswordService.PasswordHashEndEventHandler += ClosePasswordHashingModal;
         await BrowserRepository.InitializeAsync();

--- a/Crypter.Web/Shared/MainLayout.razor.cs
+++ b/Crypter.Web/Shared/MainLayout.razor.cs
@@ -43,10 +43,8 @@ namespace Crypter.Web.Shared;
 public class MainLayoutBase : LayoutComponentBase, IDisposable
 {
     [Inject] private IBlazorSodiumService BlazorSodiumService { get; init; } = null!;
-
-    [Inject] private IUserSessionService UserSessionService { get; init; } = null!;
-
-    [Inject] private IUserKeysService UserKeysService { get; init; } = null!;
+    
+    [Inject] private IEventfulUserKeysService EventfulUserKeysService { get; init; } = null!;
 
     [Inject] private IUserPasswordService UserPasswordService { get; init; } = null!;
 
@@ -63,7 +61,7 @@ public class MainLayoutBase : LayoutComponentBase, IDisposable
 
     protected override async Task OnInitializedAsync()
     {
-        UserKeysService.EmitRecoveryKeyEventHandler += HandleRecoveryKeyCreatedEvent;
+        EventfulUserKeysService.EmitRecoveryKeyEventHandler += HandleRecoveryKeyCreatedEvent;
         UserPasswordService.PasswordHashBeginEventHandler += ShowPasswordHashingModal;
         UserPasswordService.PasswordHashEndEventHandler += ClosePasswordHashingModal;
         await BrowserRepository.InitializeAsync();
@@ -103,7 +101,7 @@ public class MainLayoutBase : LayoutComponentBase, IDisposable
 
     public void Dispose()
     {
-        UserKeysService.EmitRecoveryKeyEventHandler -= HandleRecoveryKeyCreatedEvent;
+        EventfulUserKeysService.EmitRecoveryKeyEventHandler -= HandleRecoveryKeyCreatedEvent;
         UserPasswordService.PasswordHashBeginEventHandler -= ShowPasswordHashingModal;
         UserPasswordService.PasswordHashEndEventHandler -= ClosePasswordHashingModal;
         GC.SuppressFinalize(this);

--- a/Crypter.Web/Shared/MainLayout.razor.cs
+++ b/Crypter.Web/Shared/MainLayout.razor.cs
@@ -71,18 +71,6 @@ public class MainLayoutBase : LayoutComponentBase, IDisposable
         ServicesInitialized = true;
     }
 
-    private void ShowUserKeysProgressModal(object? _, EventArgs __)
-    {
-        SpinnerModal.Open("Preparing Secret Keys",
-            "Please wait while your secret keys are being prepared.",
-            Maybe<EventCallback>.None);
-    }
-
-    private async void CloseUserKeysProgressModal(object? _, EventArgs __)
-    {
-        await SpinnerModal.CloseAsync();
-    }
-
     private void HandleRecoveryKeyCreatedEvent(object? _, EmitRecoveryKeyEventArgs args)
     {
         RecoveryKeyModal.Open(args.RecoveryKey);

--- a/Crypter.Web/Shared/MainLayout.razor.cs
+++ b/Crypter.Web/Shared/MainLayout.razor.cs
@@ -63,8 +63,7 @@ public class MainLayoutBase : LayoutComponentBase, IDisposable
 
     protected override async Task OnInitializedAsync()
     {
-        UserSessionService.UserLoggedInEventHandler += HandleUserLoggedInEvent;
-        UserKeysService.RecoveryKeyCreatedEventHandler += HandleRecoveryKeyCreatedEvent;
+        UserKeysService.EmitRecoveryKeyEventHandler += HandleRecoveryKeyCreatedEvent;
         UserPasswordService.PasswordHashBeginEventHandler += ShowPasswordHashingModal;
         UserPasswordService.PasswordHashEndEventHandler += ClosePasswordHashingModal;
         await BrowserRepository.InitializeAsync();
@@ -74,15 +73,7 @@ public class MainLayoutBase : LayoutComponentBase, IDisposable
         ServicesInitialized = true;
     }
 
-    private async void HandleUserLoggedInEvent(object? _, UserLoggedInEventArgs args)
-    {
-        if (args.ShowRecoveryKeyModal)
-        {
-            await RecoveryKeyModal.OpenAsync(args.VersionedPassword);
-        }
-    }
-
-    private void HandleRecoveryKeyCreatedEvent(object? _, RecoveryKeyCreatedEventArgs args)
+    private void HandleRecoveryKeyCreatedEvent(object? _, EmitRecoveryKeyEventArgs args)
     {
         RecoveryKeyModal.Open(args.RecoveryKey);
     }
@@ -112,8 +103,7 @@ public class MainLayoutBase : LayoutComponentBase, IDisposable
 
     public void Dispose()
     {
-        UserSessionService.UserLoggedInEventHandler -= HandleUserLoggedInEvent;
-        UserKeysService.RecoveryKeyCreatedEventHandler -= HandleRecoveryKeyCreatedEvent;
+        UserKeysService.EmitRecoveryKeyEventHandler -= HandleRecoveryKeyCreatedEvent;
         UserPasswordService.PasswordHashBeginEventHandler -= ShowPasswordHashingModal;
         UserPasswordService.PasswordHashEndEventHandler -= ClosePasswordHashingModal;
         GC.SuppressFinalize(this);

--- a/Crypter.Web/Shared/MainLayout.razor.cs
+++ b/Crypter.Web/Shared/MainLayout.razor.cs
@@ -71,6 +71,18 @@ public class MainLayoutBase : LayoutComponentBase, IDisposable
         ServicesInitialized = true;
     }
 
+    private void ShowUserKeysProgressModal(object? _, EventArgs __)
+    {
+        SpinnerModal.Open("Preparing Secret Keys",
+            "Please wait while your secret keys are being prepared.",
+            Maybe<EventCallback>.None);
+    }
+
+    private async void CloseUserKeysProgressModal(object? _, EventArgs __)
+    {
+        await SpinnerModal.CloseAsync();
+    }
+
     private void HandleRecoveryKeyCreatedEvent(object? _, EmitRecoveryKeyEventArgs args)
     {
         RecoveryKeyModal.Open(args.RecoveryKey);

--- a/Crypter.Web/Shared/Modal/RecoveryKeyModal.razor.cs
+++ b/Crypter.Web/Shared/Modal/RecoveryKeyModal.razor.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2024 Crypter File Transfer
+ * Copyright (C) 2025 Crypter File Transfer
  *
  * This file is part of the Crypter file transfer project.
  *
@@ -24,12 +24,10 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System;
 using System.Threading.Tasks;
 using Crypter.Common.Client.Interfaces.HttpClients;
 using Crypter.Common.Client.Interfaces.Services;
 using Crypter.Common.Client.Models;
-using Crypter.Common.Contracts.Features.UserAuthentication;
 using Crypter.Web.Shared.Modal.Template;
 using EasyMonads;
 using Microsoft.AspNetCore.Components;
@@ -50,39 +48,16 @@ public partial class RecoveryKeyModal
     private string _recoveryKey = string.Empty;
 
     private ModalBehavior _modalBehaviorRef = null!;
-    
-    private bool _isOpen = false;
-
-    public async Task OpenAsync(VersionedPassword versionedPassword)
-    {
-        if (!_isOpen)
-        {
-            _isOpen = true;
-            Maybe<RecoveryKey> recoveryKey = await UserKeysService.MasterKey
-                .BindAsync(async masterKey => await UserRecoveryService.DeriveRecoveryKeyAsync(masterKey, versionedPassword));
-            _recoveryKey = RecoveryKeyToString(recoveryKey);
-            _modalBehaviorRef.Open();
-        }
-    }
 
     public void Open(Maybe<RecoveryKey> recoveryKey)
     {
-        if (!_isOpen)
-        {
-            _isOpen = true;
-            _recoveryKey = RecoveryKeyToString(recoveryKey);
-            _modalBehaviorRef.Open();
-        }
-    }
-
-    private string RecoveryKeyToString(Maybe<RecoveryKey> recoveryKey)
-    {
-        return recoveryKey
+        _recoveryKey = recoveryKey
             .Match(
                 none: () => "An error occurred",
                 some: x => x.ToBase64String());
+        _modalBehaviorRef.Open();
     }
-
+    
     private async Task CopyRecoveryKeyToClipboardAsync()
     {
         await JsRuntime.InvokeVoidAsync("Crypter.CopyToClipboard", _recoveryKey, "recoveryKeyModalCopyTooltip");
@@ -92,6 +67,5 @@ public partial class RecoveryKeyModal
     {
         await CrypterApiService.UserConsent.ConsentToRecoveryKeyRisksAsync();
         _modalBehaviorRef.Close();
-        _isOpen = false;
     }
 }

--- a/Crypter.Web/Shared/Modal/SpinnerModal.razor.cs
+++ b/Crypter.Web/Shared/Modal/SpinnerModal.razor.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2024 Crypter File Transfer
+ * Copyright (C) 2025 Crypter File Transfer
  *
  * This file is part of the Crypter file transfer project.
  *
@@ -24,7 +24,6 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
-using System;
 using System.Threading.Tasks;
 using Crypter.Web.Shared.Modal.Template;
 using EasyMonads;

--- a/Crypter.Web/Shared/Modal/SpinnerModal.razor.cs
+++ b/Crypter.Web/Shared/Modal/SpinnerModal.razor.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2025 Crypter File Transfer
+ * Copyright (C) 2024 Crypter File Transfer
  *
  * This file is part of the Crypter file transfer project.
  *
@@ -24,6 +24,7 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
+using System;
 using System.Threading.Tasks;
 using Crypter.Web.Shared.Modal.Template;
 using EasyMonads;

--- a/Crypter.Web/Shared/Transfer/UploadFileTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/UploadFileTransfer.razor.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2023 Crypter File Transfer
+ * Copyright (C) 2025 Crypter File Transfer
  *
  * This file is part of the Crypter file transfer project.
  *
@@ -138,7 +138,7 @@ public partial class UploadFileTransfer : IDisposable
             await Task.Delay(400);
         }
         
-        await HandleUploadResponse(uploadResponse);
+        await HandleUploadResponseAsync(uploadResponse);
         Dispose();
         return;
 

--- a/Crypter.Web/Shared/Transfer/UploadMessageTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/UploadMessageTransfer.razor.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2023 Crypter File Transfer
+ * Copyright (C) 2025 Crypter File Transfer
  *
  * This file is part of the Crypter file transfer project.
  *
@@ -25,7 +25,12 @@
  */
 
 using System;
+using System.Reflection.Metadata;
 using System.Threading.Tasks;
+using Crypter.Common.Client.Transfer.Handlers;
+using Crypter.Common.Client.Transfer.Models;
+using Crypter.Common.Contracts.Features.Transfer;
+using EasyMonads;
 
 namespace Crypter.Web.Shared.Transfer;
 
@@ -40,17 +45,16 @@ public partial class UploadMessageTransfer : IDisposable
         EncryptionInProgress = true;
         ErrorMessage = string.Empty;
 
-        await SetProgressMessage("Encrypting message");
-        var messageUploader =
-            TransferHandlerFactory.CreateUploadMessageHandler(MessageSubject, MessageBody, ExpirationHours);
+        await SetProgressMessageAsync("Encrypting message");
+        UploadMessageHandler messageUploader = TransferHandlerFactory.CreateUploadMessageHandler(MessageSubject, MessageBody, ExpirationHours);
 
         SetHandlerUserInfo(messageUploader);
-        var uploadResponse = await messageUploader.UploadAsync();
-        await HandleUploadResponse(uploadResponse);
+        Either<UploadTransferError, UploadHandlerResponse> uploadResponse = await messageUploader.UploadAsync();
+        await HandleUploadResponseAsync(uploadResponse);
         Dispose();
     }
 
-    protected async Task SetProgressMessage(string message)
+    protected async Task SetProgressMessageAsync(string message)
     {
         UploadStatusMessage = message;
         StateHasChanged();

--- a/Crypter.Web/Shared/Transfer/UploadTransferBase.cs
+++ b/Crypter.Web/Shared/Transfer/UploadTransferBase.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2024 Crypter File Transfer
+ * Copyright (C) 2025 Crypter File Transfer
  *
  * This file is part of the Crypter file transfer project.
  *
@@ -33,7 +33,6 @@ using Crypter.Common.Client.Transfer.Handlers.Base;
 using Crypter.Common.Client.Transfer.Models;
 using Crypter.Common.Contracts.Features.Transfer;
 using Crypter.Common.Enums;
-using Crypter.Web.Services;
 using Crypter.Web.Shared.Modal;
 using EasyMonads;
 using Microsoft.AspNetCore.Components;
@@ -52,8 +51,6 @@ public class UploadTransferBase : ComponentBase
     [Inject] protected ClientTransferSettings ClientTransferSettings { get; init; } = null!;
 
     [Inject] protected TransferHandlerFactory TransferHandlerFactory { get; init; } = null!;
-
-    [Inject] protected IFileSaverService FileSaverService { get; init; } = null!;
 
     [Parameter] public Maybe<string> RecipientUsername { get; set; }
 
@@ -99,7 +96,7 @@ public class UploadTransferBase : ComponentBase
         });
     }
 
-    protected async Task HandleUploadResponse(Either<UploadTransferError, UploadHandlerResponse> uploadResponse)
+    protected async Task HandleUploadResponseAsync(Either<UploadTransferError, UploadHandlerResponse> uploadResponse)
     {
         await uploadResponse
             .DoRightAsync(async response =>

--- a/Crypter.Web/Shared/UserSettings/UserSettingsKeys.razor.cs
+++ b/Crypter.Web/Shared/UserSettings/UserSettingsKeys.razor.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (C) 2024 Crypter File Transfer
+ * Copyright (C) 2025 Crypter File Transfer
  *
  * This file is part of the Crypter file transfer project.
  *
@@ -62,8 +62,7 @@ public partial class UserSettingsKeys : IDisposable
     private async void OnPasswordTestSuccess(object? sender, UserPasswordTestSuccessEventArgs args)
     {
         _recoveryKey = await UserKeysService.MasterKey
-            .BindAsync(async masterKey =>
-                await UserRecoveryService.DeriveRecoveryKeyAsync(masterKey, args.Username, args.Password))
+            .BindAsync(async masterKey => await UserRecoveryService.DeriveRecoveryKeyAsync(masterKey, args.Username, args.Password))
             .MatchAsync(
                 () => "An error occurred",
                 x => x.ToBase64String());

--- a/Crypter.Web/Shared/UserSettings/UserSettingsKeys.razor.cs
+++ b/Crypter.Web/Shared/UserSettings/UserSettingsKeys.razor.cs
@@ -40,9 +40,7 @@ public partial class UserSettingsKeys : IDisposable
     [Inject] private IUserSessionService UserSessionService { get; init; } = null!;
 
     [Inject] private IUserKeysService UserKeysService { get; init; } = null!;
-
-    [Inject] private IUserRecoveryService UserRecoveryService { get; init; } = null!;
-
+    
     [Inject] private IJSRuntime JsRuntime { get; init; } = null!;
 
     private PasswordChallengeModal _passwordModal = null!;
@@ -62,7 +60,7 @@ public partial class UserSettingsKeys : IDisposable
     private async void OnPasswordTestSuccess(object? sender, UserPasswordTestSuccessEventArgs args)
     {
         _recoveryKey = await UserKeysService.MasterKey
-            .BindAsync(async masterKey => await UserRecoveryService.DeriveRecoveryKeyAsync(masterKey, args.Username, args.Password))
+            .BindAsync(async masterKey => await UserKeysService.DeriveRecoveryKeyAsync(masterKey, args.Username, args.Password))
             .MatchAsync(
                 () => "An error occurred",
                 x => x.ToBase64String());

--- a/Crypter.Web/wwwroot/appsettings.Development.json
+++ b/Crypter.Web/wwwroot/appsettings.Development.json
@@ -1,5 +1,8 @@
 {
    "ApiSettings": {
       "ApiBaseUrl": "https://localhost/api"
+   },
+   "LoggingConfiguration": {
+      "MinimumLogLevel": "Debug"
    }
 }

--- a/Crypter.Web/wwwroot/appsettings.Staging.json
+++ b/Crypter.Web/wwwroot/appsettings.Staging.json
@@ -1,11 +1,8 @@
 {
-  "ApiSettings": {
-    "ApiBaseUrl": "${API_BASE_URL}"
-  },
-  "Logging": {
-    "LogLevel": {
-      "Default": "Debug",
-      "Microsoft.AspNetCore": "Information"
-    }
-  }
+   "ApiSettings": {
+      "ApiBaseUrl": "${API_BASE_URL}"
+   },
+   "LoggingConfiguration": {
+      "MinimumLogLevel": "Debug"
+   }
 }

--- a/Crypter.Web/wwwroot/appsettings.json
+++ b/Crypter.Web/wwwroot/appsettings.json
@@ -13,10 +13,7 @@
       "MaxReadSize": 32704,
       "PadSize": 64
    },
-   "Logging": {
-      "LogLevel": {
-         "Default": "Warning",
-         "Microsoft.AspNetCore": "Warning"
-      }
+   "LoggingConfiguration": {
+      "MinimumLogLevel": "Information"
    }
 }


### PR DESCRIPTION
The web client should stop depending on the LoginResponse to tell it to upload new keys.

Instead, the client should attempt to fetch the keys after login.  If the API responds 404, the client should create and upload new keys for that respective 404.

In other words, if GET MasterKey returns 404, then upload a new master key.  If GET PrivateKey returns 404, then upload a new key pair.

The intent is to decouple this key management from the login request/response.  Should make implementing MFA easier in a subsequent change.