### PR TITLE
Disable entity tracking where applicable

### DIFF
--- a/Crypter.Core/Features/Keys/Commands/UpsertMasterKeyCommand.cs
+++ b/Crypter.Core/Features/Keys/Commands/UpsertMasterKeyCommand.cs
@@ -80,10 +80,10 @@ internal class UpsertMasterKeyCommandHandler : IEitherRequestHandler<UpsertMaste
             _ => InsertMasterKeyError.InvalidPassword,
             async _ =>
             {
-                UserMasterKeyEntity? masterKeyEntity = await _dataContext.UserMasterKeys
-                    .FirstOrDefaultAsync(x => x.Owner == request.UserId, CancellationToken.None);
+                bool masterKeyExists = await _dataContext.UserMasterKeys
+                    .AnyAsync(x => x.Owner == request.UserId, CancellationToken.None);
 
-                if (masterKeyEntity is not null && !request.AllowReplacement)
+                if (masterKeyExists && !request.AllowReplacement)
                 {
                     return InsertMasterKeyError.Conflict;
                 }

--- a/Crypter.Core/Features/Reports/Queries/ApplicationAnalyticsReportQuery.cs
+++ b/Crypter.Core/Features/Reports/Queries/ApplicationAnalyticsReportQuery.cs
@@ -57,7 +57,7 @@ internal sealed class ApplicationAnalyticsReportQueryHandler
         DateTimeOffset now = DateTimeOffset.UtcNow;
         DateTimeOffset reportBegin = DateTimeOffset.UtcNow.AddDays(-request.ReportPeriodDays);
         
-        List<EventLogEntity> events = await _dataContext.EventLogs
+        List<EventLogEntity> events = await _dataContext.EventLogs.AsNoTracking()
             .Where(eventLog => eventLog.Timestamp <= now && eventLog.Timestamp >= reportBegin)
             .ToListAsync(cancellationToken);
 

--- a/Crypter.Core/Features/Transfer/Events/FailedMultipartFileTransferAbandonEvent.cs
+++ b/Crypter.Core/Features/Transfer/Events/FailedMultipartFileTransferAbandonEvent.cs
@@ -30,7 +30,6 @@ using System.Threading.Tasks;
 using Crypter.Common.Contracts.Features.Transfer;
 using Crypter.Common.Enums;
 using Crypter.Core.Services;
-using Crypter.DataAccess;
 using Hangfire;
 using MediatR;
 
@@ -43,16 +42,13 @@ internal class FailedMultipartFileTransferAbandonEventHandler
     : INotificationHandler<FailedMultipartFileTransferAbandonEvent>
 {
     private readonly IBackgroundJobClient _backgroundJobClient;
-    private readonly DataContext _dataContext;
     private readonly IHangfireBackgroundService _hangfireBackgroundService;
 
     public FailedMultipartFileTransferAbandonEventHandler(
         IBackgroundJobClient backgroundJobClient,
-        DataContext dataContext,
         IHangfireBackgroundService hangfireBackgroundService)
     {
         _backgroundJobClient = backgroundJobClient;
-        _dataContext = dataContext;
         _hangfireBackgroundService = hangfireBackgroundService;
     }
     

--- a/Crypter.Core/Features/Transfer/Events/SuccessfulMultipartFileTransferAbandonEvent.cs
+++ b/Crypter.Core/Features/Transfer/Events/SuccessfulMultipartFileTransferAbandonEvent.cs
@@ -29,7 +29,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Crypter.Common.Enums;
 using Crypter.Core.Services;
-using Crypter.DataAccess;
 using Hangfire;
 using MediatR;
 
@@ -42,16 +41,13 @@ internal class SuccessfulMultipartFileTransferAbandonEventHandler
     : INotificationHandler<SuccessfulMultipartFileTransferAbandonEvent>
 {
     private readonly IBackgroundJobClient _backgroundJobClient;
-    private readonly DataContext _dataContext;
     private readonly IHangfireBackgroundService _hangfireBackgroundService;
 
     public SuccessfulMultipartFileTransferAbandonEventHandler(
         IBackgroundJobClient backgroundJobClient,
-        DataContext dataContext,
         IHangfireBackgroundService hangfireBackgroundService)
     {
         _backgroundJobClient = backgroundJobClient;
-        _dataContext = dataContext;
         _hangfireBackgroundService = hangfireBackgroundService;
     }
     

--- a/Crypter.Core/Features/UserAuthentication/Common.cs
+++ b/Crypter.Core/Features/UserAuthentication/Common.cs
@@ -92,7 +92,7 @@ internal static class Common
         Task<Either<T, UserEntity?>> FetchUserAsync<T>(T error)
         {
             return Either<T, UserEntity?>.FromRightAsync(
-                dataContext.Users.FirstOrDefaultAsync(x => x.Id == userId, cancellationToken),
+                dataContext.Users.AsNoTracking().FirstOrDefaultAsync(x => x.Id == userId, cancellationToken),
                 error);
         }
 


### PR DESCRIPTION
* Use entity existence test instead of fetching the whole entity where applicable
* Use `AsNoTracking` on DbSets where applicable
* Remove unused DbContext references

Related to #565 