### PR TITLE
Update .dockerignore to resolve 'permission denied' errors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,17 @@
+# directories
+Documentation/
+Environments/
+Volumes/
+
+.github/
+.idea/
+
 **/bin/
 **/obj/
+**/out/
+
+# files
+.env
+Dockerfile*
+docker-compose*
+**/*.md


### PR DESCRIPTION
I was encountering a `permission denied` error while building the images locally.  Add the `Volumes` directory, among other things, to the `.dockerignore` file.