### PR TITLE
Include "api/" prefix for Swagger UI

### DIFF
--- a/Crypter.API/Program.cs
+++ b/Crypter.API/Program.cs
@@ -121,8 +121,15 @@ if (app.Environment.IsDevelopment())
         x.AllowAnyOrigin();
     });
 
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    app.UseSwagger(c =>
+    {
+        c.RouteTemplate = "api/swagger/{documentname}/swagger.json";
+    });
+    app.UseSwaggerUI(c =>
+    {
+        c.SwaggerEndpoint("/api/swagger/v1/swagger.json", "Crypter.API");
+        c.RoutePrefix = "api/swagger";
+    });
 }
 else
 {

--- a/Crypter.API/Properties/launchSettings.json
+++ b/Crypter.API/Properties/launchSettings.json
@@ -12,7 +12,7 @@
       "Crypter.API": {
          "commandName": "Project",
          "launchBrowser": true,
-         "launchUrl": "swagger",
+         "launchUrl": "api/swagger",
          "environmentVariables": {
             "ASPNETCORE_ENVIRONMENT": "Development"
          },


### PR DESCRIPTION
The API running from Docker was responding 404 when requesting the Swagger page.

The Swagger page needs to be prefixed with "api/" in order to work with the Caddy reverse-proxy.