### PR TITLE
Use Base64 encoded value for JWT signing seed

### DIFF
--- a/Crypter.API/appsettings.Development.json
+++ b/Crypter.API/appsettings.Development.json
@@ -1,7 +1,6 @@
 {
   "TokenSettings": {
     "Audience": "localhost",
-    "Issuer": "localhost",
-    "SigningKeySeed": "ARandomAndUnique32ByteLongString"
+    "Issuer": "localhost"
   }
 }

--- a/Crypter.API/appsettings.json
+++ b/Crypter.API/appsettings.json
@@ -65,6 +65,6 @@
       "AuthenticationTokenLifetimeMinutes": 5,
       "SessionTokenLifetimeMinutes": 30,
       "DeviceTokenLifetimeDays": 30,
-      "SigningKeySeed": "ARandomAndUnique32ByteLongString"
+      "SigningKeySeed": "9hBvkx3TqqL5rBYOZ51FnmNFeuFz9DmyY0/odnw9Z5Y="
    }
 }

--- a/Crypter.Core/Identity/TokenKeyProvider.cs
+++ b/Crypter.Core/Identity/TokenKeyProvider.cs
@@ -33,8 +33,8 @@ namespace Crypter.Core.Identity
 {
     public class TokenKeyProvider
     {
-        public readonly EdDsaSecurityKey _publicKey;
-        public readonly EdDsaSecurityKey _privateKey;
+        private readonly EdDsaSecurityKey _publicKey;
+        private readonly EdDsaSecurityKey _privateKey;
 
         public AsymmetricSecurityKey PublicKey => _publicKey;
         public AsymmetricSecurityKey PrivateKey => _privateKey;
@@ -44,7 +44,7 @@ namespace Crypter.Core.Identity
         public TokenKeyProvider(ICrypterCryptoProvider cryptoProvider, TokenSettings settings)
         {
             byte[] decodedSigningKeySeed = Convert.FromBase64String(settings.SigningKeySeed);
-            EdDsaAlgorithm edDsa = EdDsaAlgorithm.Create(cryptoProvider, decodedSigningKeySeed);
+            EdDsaAlgorithm edDsa = new EdDsaAlgorithm(cryptoProvider, decodedSigningKeySeed);
             _privateKey = new EdDsaSecurityKey(edDsa);
             _publicKey = new EdDsaSecurityKey(edDsa);
         }

--- a/Crypter.Core/Identity/TokenKeyProvider.cs
+++ b/Crypter.Core/Identity/TokenKeyProvider.cs
@@ -23,6 +23,8 @@
  *
  * Contact the current copyright holder to discuss commercial license options.
  */
+
+using System;
 using Crypter.Core.Identity.Tokens;
 using Microsoft.IdentityModel.Tokens;
 using ICrypterCryptoProvider = Crypter.Crypto.Common.ICryptoProvider;
@@ -41,7 +43,8 @@ namespace Crypter.Core.Identity
 
         public TokenKeyProvider(ICrypterCryptoProvider cryptoProvider, TokenSettings settings)
         {
-            EdDsaAlgorithm edDsa = EdDsaAlgorithm.Create(cryptoProvider, settings.SigningKeySeed);
+            byte[] decodedSigningKeySeed = Convert.FromBase64String(settings.SigningKeySeed);
+            EdDsaAlgorithm edDsa = EdDsaAlgorithm.Create(cryptoProvider, decodedSigningKeySeed);
             _privateKey = new EdDsaSecurityKey(edDsa);
             _publicKey = new EdDsaSecurityKey(edDsa);
         }

--- a/Crypter.Core/Identity/TokenParametersProvider.cs
+++ b/Crypter.Core/Identity/TokenParametersProvider.cs
@@ -43,7 +43,7 @@ public static class TokenParametersProvider
             ValidateLifetime = true,
             ClockSkew = TokenValidationParameters.DefaultClockSkew,
             RequireExpirationTime = true,
-            ValidAlgorithms = new[] { EdDsaAlgorithm.Name }
+            ValidAlgorithms = [EdDsaAlgorithm.Name]
         };
     }
 }

--- a/Crypter.Core/Identity/Tokens/EdDsaAlgorithm.cs
+++ b/Crypter.Core/Identity/Tokens/EdDsaAlgorithm.cs
@@ -37,8 +37,8 @@ namespace Crypter.Core.Identity.Tokens
     {
         public const string Name = "EdDSA";
 
-        internal Ed25519KeyPair KeyPair { get; private set; }
-        internal ICryptoProvider CryptoProvider { get; private set; }
+        internal Ed25519KeyPair KeyPair { get; }
+        private ICryptoProvider CryptoProvider { get; }
         
         private EdDsaAlgorithm(ICryptoProvider signer)
         {

--- a/Crypter.Core/Identity/Tokens/EdDsaAlgorithm.cs
+++ b/Crypter.Core/Identity/Tokens/EdDsaAlgorithm.cs
@@ -46,7 +46,7 @@ namespace Crypter.Core.Identity.Tokens
             KeyPair = CryptoProvider.DigitalSignature.GenerateKeyPair();
         }
 
-        private EdDsaAlgorithm(ICryptoProvider signer, string seed)
+        private EdDsaAlgorithm(ICryptoProvider signer, ReadOnlySpan<byte> seed)
         {
             CryptoProvider = signer;
             KeyPair = CryptoProvider.DigitalSignature.GenerateKeyPair(seed);
@@ -57,7 +57,7 @@ namespace Crypter.Core.Identity.Tokens
             return cryptoProvider == null ? throw new ArgumentNullException(nameof(cryptoProvider)) : new EdDsaAlgorithm(cryptoProvider);
         }
 
-        public static EdDsaAlgorithm Create(ICryptoProvider? cryptoProvider, string seed)
+        public static EdDsaAlgorithm Create(ICryptoProvider? cryptoProvider, ReadOnlySpan<byte> seed)
         {
             return cryptoProvider == null ? throw new ArgumentNullException(nameof(cryptoProvider)) : new EdDsaAlgorithm(cryptoProvider, seed);
         }

--- a/Crypter.Core/Identity/Tokens/EdDsaAlgorithm.cs
+++ b/Crypter.Core/Identity/Tokens/EdDsaAlgorithm.cs
@@ -40,26 +40,16 @@ namespace Crypter.Core.Identity.Tokens
         internal Ed25519KeyPair KeyPair { get; }
         private ICryptoProvider CryptoProvider { get; }
         
-        private EdDsaAlgorithm(ICryptoProvider signer)
+        public EdDsaAlgorithm(ICryptoProvider signer)
         {
             CryptoProvider = signer;
             KeyPair = CryptoProvider.DigitalSignature.GenerateKeyPair();
         }
 
-        private EdDsaAlgorithm(ICryptoProvider signer, ReadOnlySpan<byte> seed)
+        public EdDsaAlgorithm(ICryptoProvider signer, ReadOnlySpan<byte> seed)
         {
             CryptoProvider = signer;
             KeyPair = CryptoProvider.DigitalSignature.GenerateKeyPair(seed);
-        }
-
-        public static EdDsaAlgorithm Create(ICryptoProvider? cryptoProvider)
-        {
-            return cryptoProvider == null ? throw new ArgumentNullException(nameof(cryptoProvider)) : new EdDsaAlgorithm(cryptoProvider);
-        }
-
-        public static EdDsaAlgorithm Create(ICryptoProvider? cryptoProvider, ReadOnlySpan<byte> seed)
-        {
-            return cryptoProvider == null ? throw new ArgumentNullException(nameof(cryptoProvider)) : new EdDsaAlgorithm(cryptoProvider, seed);
         }
 
         public override string SignatureAlgorithm => Name;

--- a/Crypter.Crypto.Common/DigitalSignature/IDigitalSignature.cs
+++ b/Crypter.Crypto.Common/DigitalSignature/IDigitalSignature.cs
@@ -31,7 +31,7 @@ namespace Crypter.Crypto.Common.DigitalSignature;
 public interface IDigitalSignature
 {
     Ed25519KeyPair GenerateKeyPair();
-    Ed25519KeyPair GenerateKeyPair(string seed);
+    Ed25519KeyPair GenerateKeyPair(ReadOnlySpan<byte> seed);
     byte[] GenerateSignature(ReadOnlySpan<byte> privateKey, ReadOnlySpan<byte> message);
     bool VerifySignature(ReadOnlySpan<byte> publicKey, ReadOnlySpan<byte> message, ReadOnlySpan<byte> signature);
 }

--- a/Crypter.Crypto.Providers.Browser/Wrappers/DigitalSignature.cs
+++ b/Crypter.Crypto.Providers.Browser/Wrappers/DigitalSignature.cs
@@ -40,7 +40,7 @@ public class DigitalSignature : IDigitalSignature
         return new Ed25519KeyPair(keyPair.PrivateKey, keyPair.PublicKey);
     }
 
-    public virtual Ed25519KeyPair GenerateKeyPair(ReadOnlySpan<byte> seed)
+    public Ed25519KeyPair GenerateKeyPair(ReadOnlySpan<byte> seed)
     {
         if (seed.Length != PublicKeySignature.SEED_BYTES)
         {

--- a/Crypter.Crypto.Providers.Browser/Wrappers/DigitalSignature.cs
+++ b/Crypter.Crypto.Providers.Browser/Wrappers/DigitalSignature.cs
@@ -26,7 +26,6 @@
 
 using System;
 using System.Runtime.Versioning;
-using System.Text;
 using BlazorSodium.Sodium;
 using Crypter.Crypto.Common.DigitalSignature;
 
@@ -41,14 +40,13 @@ public class DigitalSignature : IDigitalSignature
         return new Ed25519KeyPair(keyPair.PrivateKey, keyPair.PublicKey);
     }
 
-    public virtual Ed25519KeyPair GenerateKeyPair(string seed)
+    public virtual Ed25519KeyPair GenerateKeyPair(ReadOnlySpan<byte> seed)
     {
-        byte[] seedBytes = Encoding.UTF8.GetBytes(seed);
-        if (seedBytes.Length != PublicKeySignature.SEED_BYTES)
+        if (seed.Length != PublicKeySignature.SEED_BYTES)
         {
             throw new ArgumentOutOfRangeException(nameof(seed));
         }
-        BlazorSodium.Sodium.Models.Ed25519KeyPair keyPair = PublicKeySignature.Crypto_Sign_Seed_KeyPair(seedBytes);
+        BlazorSodium.Sodium.Models.Ed25519KeyPair keyPair = PublicKeySignature.Crypto_Sign_Seed_KeyPair(seed.ToArray());
         return new Ed25519KeyPair(keyPair.PrivateKey, keyPair.PublicKey);
     }
 

--- a/Crypter.Crypto.Providers.Default/Wrappers/DigitalSignature.cs
+++ b/Crypter.Crypto.Providers.Default/Wrappers/DigitalSignature.cs
@@ -46,7 +46,7 @@ public class DigitalSignature : IDigitalSignature
     {
         if (seed.Length != Ed25519.SeedSize)
         {
-            throw new ArgumentOutOfRangeException(nameof(seed));
+            throw new ArgumentOutOfRangeException(nameof(seed), "Seed must be of length Ed25519.SeedSize");
         }
         byte[] privateKey = new byte[Ed25519.PrivateKeySize];
         byte[] publicKey = new byte[Ed25519.PublicKeySize];

--- a/Crypter.Crypto.Providers.Default/Wrappers/DigitalSignature.cs
+++ b/Crypter.Crypto.Providers.Default/Wrappers/DigitalSignature.cs
@@ -42,7 +42,7 @@ public class DigitalSignature : IDigitalSignature
         return new Ed25519KeyPair(privateKey, publicKey);
     }
 
-    public virtual Ed25519KeyPair GenerateKeyPair(ReadOnlySpan<byte> seed)
+    public Ed25519KeyPair GenerateKeyPair(ReadOnlySpan<byte> seed)
     {
         if (seed.Length != Ed25519.SeedSize)
         {
@@ -51,7 +51,7 @@ public class DigitalSignature : IDigitalSignature
         byte[] privateKey = new byte[Ed25519.PrivateKeySize];
         byte[] publicKey = new byte[Ed25519.PublicKeySize];
         
-        Ed25519.GenerateKeyPair(publicKey, privateKey, seed.ToArray());
+        Ed25519.GenerateKeyPair(publicKey, privateKey, seed);
         return new Ed25519KeyPair(privateKey, publicKey);
     }
 

--- a/Crypter.Crypto.Providers.Default/Wrappers/DigitalSignature.cs
+++ b/Crypter.Crypto.Providers.Default/Wrappers/DigitalSignature.cs
@@ -26,7 +26,6 @@
 
 using System;
 using System.Runtime.Versioning;
-using System.Text;
 using Crypter.Crypto.Common.DigitalSignature;
 using Geralt;
 
@@ -43,17 +42,16 @@ public class DigitalSignature : IDigitalSignature
         return new Ed25519KeyPair(privateKey, publicKey);
     }
 
-    public virtual Ed25519KeyPair GenerateKeyPair(string seed)
+    public virtual Ed25519KeyPair GenerateKeyPair(ReadOnlySpan<byte> seed)
     {
-        byte[] seedBytes = Encoding.UTF8.GetBytes(seed);
-        if (seedBytes.Length != Ed25519.SeedSize)
+        if (seed.Length != Ed25519.SeedSize)
         {
             throw new ArgumentOutOfRangeException(nameof(seed));
         }
         byte[] privateKey = new byte[Ed25519.PrivateKeySize];
         byte[] publicKey = new byte[Ed25519.PublicKeySize];
         
-        Ed25519.GenerateKeyPair(publicKey, privateKey, seedBytes);
+        Ed25519.GenerateKeyPair(publicKey, privateKey, seed.ToArray());
         return new Ed25519KeyPair(privateKey, publicKey);
     }
 

--- a/Crypter.Test/Core_Tests/Identity_Tests/EdDsa_Tests.cs
+++ b/Crypter.Test/Core_Tests/Identity_Tests/EdDsa_Tests.cs
@@ -45,7 +45,7 @@ public class EdDsa_Tests
         byte[] toSignBytes = Encoding.UTF8.GetBytes(signableString);
 
         ICryptoProvider cryptoProvider = new DefaultCryptoProvider();
-        EdDsaAlgorithm alg = EdDsaAlgorithm.Create(cryptoProvider);
+        EdDsaAlgorithm alg = new EdDsaAlgorithm(cryptoProvider);
         Assert.That(alg, Is.Not.Null);
 
         byte[] signature = alg.Sign(toSignBytes);

--- a/Crypter.Test/Core_Tests/Identity_Tests/EdDsa_Tests.cs
+++ b/Crypter.Test/Core_Tests/Identity_Tests/EdDsa_Tests.cs
@@ -24,52 +24,49 @@
  * Contact the current copyright holder to discuss commercial license options.
  */
 
+using System;
 using Crypter.Core.Identity.Tokens;
 using Crypter.Crypto.Common;
 using Crypter.Crypto.Providers.Default;
 using NUnit.Framework;
-using System.IO;
 using System.Linq;
 using System.Text;
 using Geralt;
 
-namespace Crypter.Test.Core_Tests.Identity_Tests
+namespace Crypter.Test.Core_Tests.Identity_Tests;
+
+[TestFixture]
+public class EdDsa_Tests
 {
-    [TestFixture]
-    public class EdDsa_Tests
+    [Test]
+    public void Can_Generate_And_Verify_EdDsa_Signature()
     {
+        const string signableString = "Crypter.dev";
+        byte[] toSignBytes = Encoding.UTF8.GetBytes(signableString);
 
-        [Test]
-        public void Can_Generate_And_Verify_EdDsa_Siganture()
-        {
-            string signableString = "Crypter.dev";
-            byte[] toSignBytes = Encoding.UTF8.GetBytes(signableString);
+        ICryptoProvider cryptoProvider = new DefaultCryptoProvider();
+        EdDsaAlgorithm alg = EdDsaAlgorithm.Create(cryptoProvider);
+        Assert.That(alg, Is.Not.Null);
 
-            ICryptoProvider cryptoProvider = new DefaultCryptoProvider();
-            EdDsaAlgorithm alg = EdDsaAlgorithm.Create(cryptoProvider);
-            Assert.That(alg, Is.Not.Null);
+        byte[] signature = alg.Sign(toSignBytes);
 
-            byte[] signature = alg.Sign(toSignBytes);
+        Assert.That(alg.Verify(toSignBytes, signature));
+    }
 
-            Assert.That(alg.Verify(toSignBytes, signature));
-        }
+    [Test]
+    public void Seeded_Key_Pair_Generation_Is_Deterministic()
+    {
+        const string encodedSeed = "9hBvkx3TqqL5rBYOZ51FnmNFeuFz9DmyY0/odnw9Z5Y=";
+        byte[] seedSpan = Convert.FromBase64String(encodedSeed);
 
-        [Test]
-        [Description("It's more a test for Geralt, but it makes sure that JWT signature verification is fine between restarts.")]
-        public void Geralt_Generates_Same_Key_With_Same_Seed()
-        {
-            string seed = "abcdabcdabcdabcdabcdabcdabcdabcd";
-            byte[] seedSpan = Encoding.UTF8.GetBytes(seed);
+        byte[] privateKey1 = new byte[Ed25519.PrivateKeySize];
+        byte[] publicKey1 = new byte[Ed25519.PublicKeySize];
+        Ed25519.GenerateKeyPair(publicKey1, privateKey1, seedSpan);
 
-            byte[] privateKey1 = new byte[Ed25519.PrivateKeySize];
-            byte[] publicKey1 = new byte[Ed25519.PublicKeySize];
-            Ed25519.GenerateKeyPair(publicKey1, privateKey1, seedSpan);
+        byte[] privateKey2 = new byte[Ed25519.PrivateKeySize];
+        byte[] publicKey2 = new byte[Ed25519.PublicKeySize];
+        Ed25519.GenerateKeyPair(publicKey2, privateKey2, seedSpan);
 
-            byte[] privateKey2 = new byte[Ed25519.PrivateKeySize];
-            byte[] publicKey2 = new byte[Ed25519.PublicKeySize];
-            Ed25519.GenerateKeyPair(publicKey2, privateKey2, seedSpan);
-
-            Assert.That(privateKey1.SequenceEqual(privateKey2));
-        }
+        Assert.That(privateKey1.SequenceEqual(privateKey2));
     }
 }

--- a/Crypter.Test/Core_Tests/Services_Tests/HangfireBackgroundService_Tests.cs
+++ b/Crypter.Test/Core_Tests/Services_Tests/HangfireBackgroundService_Tests.cs
@@ -27,7 +27,6 @@
 using System;
 using System.Threading.Tasks;
 using Crypter.Common.Primitives;
-using Crypter.Core.Models;
 using Crypter.Core.Services;
 using Crypter.Core.Services.Email;
 using MediatR;

--- a/Crypter.Test/Core_Tests/Services_Tests/TokenService_Tests.cs
+++ b/Crypter.Test/Core_Tests/Services_Tests/TokenService_Tests.cs
@@ -52,7 +52,7 @@ public class TokenService_Tests
             AuthenticationTokenLifetimeMinutes = 5,
             SessionTokenLifetimeMinutes = 30,
             DeviceTokenLifetimeDays = 5,
-            SigningKeySeed = "abcdabcdabcdabcdabcdabcdabcdabcd"
+            SigningKeySeed = "9hBvkx3TqqL5rBYOZ51FnmNFeuFz9DmyY0/odnw9Z5Y="
         };
 
         _tokenSettings = Options.Create(tokenSettings);

--- a/Crypter.Test/Crypter.Test.csproj
+++ b/Crypter.Test/Crypter.Test.csproj
@@ -16,6 +16,7 @@
       <PackageReference Include="Azure.Identity" Version="1.13.2" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
       <PackageReference Include="Moq" Version="4.20.72" />
+      <PackageReference Include="NSubstitute" Version="5.3.0" />
       <PackageReference Include="NUnit" Version="4.3.2" />
       <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/Crypter.Test/Integration_Tests/FileTransfer_Tests/DownloadFileTransfer_Tests.cs
+++ b/Crypter.Test/Integration_Tests/FileTransfer_Tests/DownloadFileTransfer_Tests.cs
@@ -67,20 +67,17 @@ internal class DownloadFileTransfer_Tests
     [Test]
     public async Task Download_Anonymous_File_Transfer_Works()
     {
-        (Func<Action<double>?, EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) =
-            TestData.GetDefaultEncryptionStream();
+        (Func<Action<double>?, EncryptionStream> encryptionStreamOpener, byte[] keyExchangeProof) = TestData.GetDefaultEncryptionStream();
         UploadFileTransferRequest uploadRequest = new UploadFileTransferRequest(TestData.DefaultTransferFileName,
             TestData.DefaultTransferFileContentType, TestData.DefaultPublicKey, TestData.DefaultKeyExchangeNonce,
             keyExchangeProof, TestData.DefaultTransferLifetimeHours);
-        Either<UploadTransferError, UploadTransferResponse> uploadResult =
-            await _client!.FileTransfer.UploadFileTransferAsync(Maybe<string>.None, uploadRequest,
-                encryptionStreamOpener, false);
+        Either<UploadTransferError, UploadTransferResponse> uploadResult = await _client!.FileTransfer.UploadFileTransferAsync(Maybe<string>.None, uploadRequest,
+            encryptionStreamOpener,false);
 
         await uploadResult
             .DoRightAsync(async uploadResponse =>
             {
-                Either<DownloadTransferCiphertextError, StreamDownloadResponse> result =
-                    await _client!.FileTransfer.GetAnonymousFileCiphertextAsync(uploadResponse.HashId, keyExchangeProof);
+                Either<DownloadTransferCiphertextError, StreamDownloadResponse> result = await _client!.FileTransfer.GetAnonymousFileCiphertextAsync(uploadResponse.HashId, keyExchangeProof);
                 
                 Assert.That(uploadResult.IsRight, Is.True);
                 Assert.That(result.IsRight, Is.True);

--- a/Crypter.Test/Integration_Tests/Mocks.cs
+++ b/Crypter.Test/Integration_Tests/Mocks.cs
@@ -40,17 +40,14 @@ internal static class Mocks
         ICryptoProvider cryptoProviderMock = Substitute.For<ICryptoProvider>();
         cryptoProviderMock.ConstantTime.Returns(new ConstantTime());
         cryptoProviderMock.CryptoHash.Returns(new CryptoHash());
-        cryptoProviderMock.DigitalSignature.Returns(new DigitalSignature());
         cryptoProviderMock.GenericHash.Returns(new GenericHash());
         cryptoProviderMock.Padding.Returns(new Padding());
         cryptoProviderMock.Random.Returns(new Random());
 
-        DigitalSignature digitalSignatureMock = Substitute.For<DigitalSignature>();
+        DigitalSignature digitalSignatureMock = Substitute.ForPartsOf<DigitalSignature>();
         digitalSignatureMock.GenerateKeyPair().Returns(keyPairToReturn);
-        digitalSignatureMock.GenerateKeyPair(default).ReturnsForAnyArgs(keyPairToReturn);
 
         cryptoProviderMock.DigitalSignature.Returns(digitalSignatureMock);
-
         return cryptoProviderMock;
     }
 }

--- a/Crypter.Test/Integration_Tests/Mocks.cs
+++ b/Crypter.Test/Integration_Tests/Mocks.cs
@@ -28,46 +28,28 @@ using Crypter.Crypto.Common;
 using Crypter.Crypto.Common.CryptoHash;
 using Crypter.Crypto.Common.DigitalSignature;
 using Crypter.Crypto.Providers.Default.Wrappers;
-using Moq;
+using NSubstitute;
+using Random = Crypter.Crypto.Providers.Default.Wrappers.Random;
 
 namespace Crypter.Test.Integration_Tests;
 
 internal static class Mocks
 {
-    internal static Mock<ICryptoProvider> CreateDeterministicCryptoProvider(Ed25519KeyPair keyPairToReturn)
+    internal static ICryptoProvider CreateDeterministicCryptoProvider(Ed25519KeyPair keyPairToReturn)
     {
-        Mock<ICryptoProvider> cryptoProviderMock = new Mock<ICryptoProvider>(MockBehavior.Strict)
-        {
-            CallBase = true
-        };
+        ICryptoProvider cryptoProviderMock = Substitute.For<ICryptoProvider>();
+        cryptoProviderMock.ConstantTime.Returns(new ConstantTime());
+        cryptoProviderMock.CryptoHash.Returns(new CryptoHash());
+        cryptoProviderMock.DigitalSignature.Returns(new DigitalSignature());
+        cryptoProviderMock.GenericHash.Returns(new GenericHash());
+        cryptoProviderMock.Padding.Returns(new Padding());
+        cryptoProviderMock.Random.Returns(new Random());
 
-        cryptoProviderMock.Setup(x => x.ConstantTime)
-            .Returns(new ConstantTime());
+        DigitalSignature digitalSignatureMock = Substitute.For<DigitalSignature>();
+        digitalSignatureMock.GenerateKeyPair().Returns(keyPairToReturn);
+        digitalSignatureMock.GenerateKeyPair(default).ReturnsForAnyArgs(keyPairToReturn);
 
-        cryptoProviderMock.Setup(x => x.CryptoHash)
-            .Returns(new CryptoHash());
-
-        cryptoProviderMock.Setup(x => x.DigitalSignature)
-            .Returns(new DigitalSignature());
-
-        cryptoProviderMock.Setup(x => x.GenericHash)
-            .Returns(new GenericHash());
-
-        cryptoProviderMock.Setup(x => x.Padding)
-            .Returns(new Padding());
-
-        cryptoProviderMock.Setup(x => x.Random)
-            .Returns(new Random());
-
-        Mock<DigitalSignature> digitalSignatureMock = new Mock<DigitalSignature>
-        {
-            CallBase = true
-        };
-        digitalSignatureMock.Setup(x => x.GenerateKeyPair())
-            .Returns(keyPairToReturn);
-
-        cryptoProviderMock.Setup(x => x.DigitalSignature)
-            .Returns(digitalSignatureMock.Object);
+        cryptoProviderMock.DigitalSignature.Returns(digitalSignatureMock);
 
         return cryptoProviderMock;
     }

--- a/Crypter.Test/Integration_Tests/UserRecovery_Tests/SubmitRecovery_Tests.cs
+++ b/Crypter.Test/Integration_Tests/UserRecovery_Tests/SubmitRecovery_Tests.cs
@@ -70,7 +70,7 @@ internal class SubmitRecovery_Tests
     {
         _cryptoProvider = new DefaultCryptoProvider();
         _knownKeyPair = _cryptoProvider.DigitalSignature.GenerateKeyPair();
-        _mockCryptoProvider = Mocks.CreateDeterministicCryptoProvider(_knownKeyPair).Object;
+        _mockCryptoProvider = Mocks.CreateDeterministicCryptoProvider(_knownKeyPair);
         
         IServiceCollection overrideServices = new ServiceCollection();
         overrideServices.AddSingleton(_mockCryptoProvider!);

--- a/Crypter.Test/Integration_Tests/UserSettings_Tests/EmailAddressVerification_Tests.cs
+++ b/Crypter.Test/Integration_Tests/UserSettings_Tests/EmailAddressVerification_Tests.cs
@@ -57,7 +57,7 @@ internal class EmailAddressVerification_Tests
     {
         _cryptoProvider = new DefaultCryptoProvider();
         _emailVerificationKeyPair = _cryptoProvider.DigitalSignature.GenerateKeyPair();
-        ICryptoProvider mockCryptoProvider = Mocks.CreateDeterministicCryptoProvider(_emailVerificationKeyPair).Object;
+        ICryptoProvider mockCryptoProvider = Mocks.CreateDeterministicCryptoProvider(_emailVerificationKeyPair);
         IServiceCollection overrideServices = new ServiceCollection();
         overrideServices.AddSingleton(mockCryptoProvider);
 
@@ -68,10 +68,8 @@ internal class EmailAddressVerification_Tests
     [Test]
     public async Task Email_Address_Verification_Works_Async()
     {
-        RegistrationRequest registrationRequest = TestData.GetRegistrationRequest(TestData.DefaultUsername,
-            TestData.DefaultPassword, TestData.DefaultEmailAdress);
-        Either<RegistrationError, Unit> _ =
-            await _client!.UserAuthentication.RegisterAsync(registrationRequest);
+        RegistrationRequest registrationRequest = TestData.GetRegistrationRequest(TestData.DefaultUsername, TestData.DefaultPassword, TestData.DefaultEmailAdress);
+        Either<RegistrationError, Unit> _ = await _client!.UserAuthentication.RegisterAsync(registrationRequest);
 
         // Allow the background service to "send" the verification email and save the email verification data
         await Task.Delay(5000);
@@ -83,9 +81,7 @@ internal class EmailAddressVerification_Tests
             .FirstAsync();
 
         string encodedVerificationCode = UrlSafeEncoder.EncodeGuidUrlSafe(verificationData.Code);
-        byte[] signedVerificationCode =
-            _cryptoProvider!.DigitalSignature.GenerateSignature(_emailVerificationKeyPair!.PrivateKey,
-                verificationData.Code.ToByteArray());
+        byte[] signedVerificationCode = _cryptoProvider!.DigitalSignature.GenerateSignature(_emailVerificationKeyPair!.PrivateKey, verificationData.Code.ToByteArray());
         string encodedSignature = UrlSafeEncoder.EncodeBytesUrlSafe(signedVerificationCode);
 
         VerifyEmailAddressRequest request = new VerifyEmailAddressRequest(encodedVerificationCode, encodedSignature);

--- a/Crypter.Test/appsettings.Test.json
+++ b/Crypter.Test/appsettings.Test.json
@@ -51,7 +51,7 @@
     "AuthenticationTokenLifetimeMinutes": 1,
     "SessionTokenLifetimeMinutes": 2,
     "DeviceTokenLifetimeDays": 2,
-    "SigningKeySeed": "ARandomAndUnique32ByteLongString"
+    "SigningKeySeed": "9hBvkx3TqqL5rBYOZ51FnmNFeuFz9DmyY0/odnw9Z5Y="
   },
   "ClientTransferSettings": {
     "MaximumUploadBufferSizeMB": 100,

--- a/Volumes/API/appsettings.json
+++ b/Volumes/API/appsettings.json
@@ -54,7 +54,7 @@
       "AuthenticationTokenLifetimeMinutes": 5,
       "SessionTokenLifetimeMinutes": 30,
       "DeviceTokenLifetimeDays": 30,
-      "SigningKeySeed": "CHANGE_ME_Unique32ByteLongString"
+      "SigningKeySeed": "9hBvkx3TqqL5rBYOZ51FnmNFeuFz9DmyY0/odnw9Z5Y="
    },
    "UploadSettings": {
       "MaxUploadSizeMB": 100,


### PR DESCRIPTION
Use a base64 encoded value for the JWT signing key seed instead of UTF8.  I figure this will make better use of the 32 bytes.