### PR TITLE
Configure the client's maximum message length using TransferTier data

### DIFF
--- a/Crypter.Common.Client/Interfaces/Services/UserSettings/IUserTransferSettingsService.cs
+++ b/Crypter.Common.Client/Interfaces/Services/UserSettings/IUserTransferSettingsService.cs
@@ -34,6 +34,7 @@ public interface IUserTransferSettingsService
 {
     Task<Maybe<GetTransferSettingsResponse>> GetTransferSettingsAsync();
     Task<long> GetAbsoluteMaximumUploadSizeAsync();
+    Task<int> GetAbsoluteMaximumMessageLengthAsync();
     Task<long> GetCurrentMaximumUploadSizeAsync();
     Task<bool> IsUserQuotaReachedAsync();
     Task<bool> IsFreeTransferQuotaReachedAsync();

--- a/Crypter.Common.Client/Services/UserSettings/UserTransferSettingsService.cs
+++ b/Crypter.Common.Client/Services/UserSettings/UserTransferSettingsService.cs
@@ -36,7 +36,7 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace Crypter.Common.Client.Services.UserSettings;
 
-public class UserTransferSettingsService : IUserTransferSettingsService
+public class UserTransferSettingsService : IUserTransferSettingsService, IDisposable
 {
     private readonly IUserSessionService _userSessionService;
     private readonly ICrypterApiClient _crypterApiClient;
@@ -44,20 +44,24 @@ public class UserTransferSettingsService : IUserTransferSettingsService
     private readonly IMemoryCache _memoryCache;
     private readonly SemaphoreSlim _memoryCacheLock = new SemaphoreSlim(1, 1);
     
+    private const string TransferSettingsCacheKey = $"{nameof(UserTransferSettingsService)}:TransferSettings";
+    
     public UserTransferSettingsService(IUserSessionService userSessionService, ICrypterApiClient crypterApiClient, IMemoryCache memoryCache)
     {
         _userSessionService = userSessionService;
         _crypterApiClient = crypterApiClient;
         _memoryCache = memoryCache;
+
+        userSessionService.UserLoggedInEventHandler += RecycleAsync;
+        userSessionService.UserLoggedOutEventHandler += RecycleAsync;
     }
     
     public async Task<Maybe<GetTransferSettingsResponse>> GetTransferSettingsAsync()
     {
-        const string cacheKey = $"{nameof(UserTransferSettingsService)}:{nameof(GetTransferSettingsAsync)}";
         try
         {
             await _memoryCacheLock.WaitAsync();
-            return await _memoryCache.GetOrCreateAsync<GetTransferSettingsResponse?>(cacheKey, async entry =>
+            return await _memoryCache.GetOrCreateAsync<GetTransferSettingsResponse?>(TransferSettingsCacheKey, async entry =>
             {
                 bool isLoggedIn = await _userSessionService.IsLoggedInAsync();
                 Maybe<GetTransferSettingsResponse> uploadSettings = await _crypterApiClient.UserSetting.GetTransferSettingsAsync(isLoggedIn);
@@ -106,5 +110,25 @@ public class UserTransferSettingsService : IUserTransferSettingsService
         return await GetTransferSettingsAsync()
             .Select(x => x.AvailableFreeTransferSpace == 0)
             .SomeOrDefaultAsync(true);
+    }
+    
+    private async void RecycleAsync(object? _, EventArgs __)
+    {
+        try
+        {
+            await _memoryCacheLock.WaitAsync();
+            _memoryCache.Remove(TransferSettingsCacheKey);
+        }
+        finally
+        {
+            _memoryCacheLock.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        _userSessionService.UserLoggedInEventHandler -= RecycleAsync;
+        _userSessionService.UserLoggedOutEventHandler -= RecycleAsync;
+        GC.SuppressFinalize(this);
     }
 }

--- a/Crypter.Common.Client/Services/UserSettings/UserTransferSettingsService.cs
+++ b/Crypter.Common.Client/Services/UserSettings/UserTransferSettingsService.cs
@@ -76,32 +76,35 @@ public class UserTransferSettingsService : IUserTransferSettingsService
     public async Task<long> GetAbsoluteMaximumUploadSizeAsync()
     {
         return await GetTransferSettingsAsync()
-            .MatchAsync(
-                () => 0,
-                x => x.MaximumUploadSize);
+            .Select(x => x.MaximumUploadSize)
+            .SomeOrDefaultAsync(0);
+    }
+
+    public async Task<int> GetAbsoluteMaximumMessageLengthAsync()
+    {
+        return await GetTransferSettingsAsync()
+            .Select(x => x.MaximumMessageLength)
+            .SomeOrDefaultAsync(0);
     }
     
     public async Task<long> GetCurrentMaximumUploadSizeAsync()
     {
         return await GetTransferSettingsAsync()
-            .MatchAsync(
-                () => 0,
-                x => Math.Min(x.MaximumUploadSize, Math.Min(x.AvailableUserSpace, x.AvailableFreeTransferSpace)));
+            .Select(x => Math.Min(x.MaximumUploadSize, Math.Min(x.AvailableUserSpace, x.AvailableFreeTransferSpace)))
+            .SomeOrDefaultAsync(0);
     }
 
     public async Task<bool> IsUserQuotaReachedAsync()
     {
         return await GetTransferSettingsAsync()
-            .MatchAsync(
-                () => true,
-                x => x.AvailableUserSpace == 0);
+            .Select(x => x.AvailableUserSpace == 0)
+            .SomeOrDefaultAsync(true);
     }
     
     public async Task<bool> IsFreeTransferQuotaReachedAsync()
     {
         return await GetTransferSettingsAsync()
-            .MatchAsync(
-                () => true,
-                x => x.AvailableFreeTransferSpace == 0);
+            .Select(x => x.AvailableFreeTransferSpace == 0)
+            .SomeOrDefaultAsync(true);
     }
 }

--- a/Crypter.Common/Contracts/Features/UserSettings/TransferSettings/GetTransferSettingsResponse.cs
+++ b/Crypter.Common/Contracts/Features/UserSettings/TransferSettings/GetTransferSettingsResponse.cs
@@ -30,6 +30,7 @@ public sealed record GetTransferSettingsResponse
 {
     public string TierName { get; set; }
     public long MaximumUploadSize { get; init; }
+    public int MaximumMessageLength { get; init; }
     public long AvailableUserSpace { get; init; }
     public long UsedUserSpace { get; init; }
     public long UserQuota { get; init; }
@@ -37,10 +38,11 @@ public sealed record GetTransferSettingsResponse
     public long UsedFreeTransferSpace { get; init; }
     public long FreeTransferQuota { get; init; }
 
-    public GetTransferSettingsResponse(string tierName, long maximumUploadSize, long availableUserSpace, long usedUserSpace, long userQuota, long availableFreeTransferSpace, long usedFreeTransferSpace, long freeTransferQuota)
+    public GetTransferSettingsResponse(string tierName, long maximumUploadSize, int maximumMessageLength, long availableUserSpace, long usedUserSpace, long userQuota, long availableFreeTransferSpace, long usedFreeTransferSpace, long freeTransferQuota)
     {
         TierName = tierName;
         MaximumUploadSize = maximumUploadSize;
+        MaximumMessageLength = maximumMessageLength;
         AvailableUserSpace = availableUserSpace;
         UsedUserSpace = usedUserSpace;
         UserQuota = userQuota;

--- a/Crypter.Core/Features/Transfer/Commands/SaveFileTransferCommand.cs
+++ b/Crypter.Core/Features/Transfer/Commands/SaveFileTransferCommand.cs
@@ -58,7 +58,6 @@ internal class SaveFileTransferCommandHandler
     private readonly IHashIdService _hashIdService;
     private readonly IPublisher _publisher;
     private readonly ITransferRepository _transferRepository;
-    private readonly TransferStorageSettings _transferStorageSettings;
 
     public SaveFileTransferCommandHandler(
         DataContext dataContext,
@@ -71,7 +70,6 @@ internal class SaveFileTransferCommandHandler
         _hashIdService = hashIdService;
         _publisher = publisher;
         _transferRepository = transferRepository;
-        _transferStorageSettings = transferStorageSettings.Value;
     }
     
     public async Task<Either<UploadTransferError, UploadTransferResponse>> Handle(SaveFileTransferCommand request, CancellationToken cancellationToken)

--- a/Crypter.Core/Features/Transfer/Commands/SaveMessageTransferCommand.cs
+++ b/Crypter.Core/Features/Transfer/Commands/SaveMessageTransferCommand.cs
@@ -58,7 +58,6 @@ internal class SaveMessageTransferCommandHandler
     private readonly IHashIdService _hashIdService;
     private readonly IPublisher _publisher;
     private readonly ITransferRepository _transferRepository;
-    private readonly TransferStorageSettings _transferStorageSettings;
 
     public SaveMessageTransferCommandHandler(
         DataContext dataContext,
@@ -71,7 +70,6 @@ internal class SaveMessageTransferCommandHandler
         _hashIdService = hashIdService;
         _publisher = publisher;
         _transferRepository = transferRepository;
-        _transferStorageSettings = transferStorageSettings.Value;
     }
 
     public async Task<Either<UploadTransferError, UploadTransferResponse>> Handle(SaveMessageTransferCommand request, CancellationToken cancellationToken)

--- a/Crypter.Core/Features/Transfer/Common.cs
+++ b/Crypter.Core/Features/Transfer/Common.cs
@@ -178,8 +178,7 @@ internal static class Common
     private static async Task<bool> HasSpaceForTransferAsync(DataContext dataContext, Maybe<Guid> possibleUserId, long ciphertextStreamLength, CancellationToken cancellationToken = default)
     {
         return await UserSettings.Common.GetUserTransferSettingsAsync(dataContext, possibleUserId, cancellationToken)
-            .MatchAsync(
-                () => false,
-                x => Math.Min(x.MaximumUploadSize, Math.Min(x.AvailableFreeTransferSpace, x.AvailableUserSpace)) >= ciphertextStreamLength);
+            .Select(x => Math.Min(x.MaximumUploadSize, Math.Min(x.AvailableFreeTransferSpace, x.AvailableUserSpace)) >= ciphertextStreamLength)
+            .SomeOrDefaultAsync(false);
     }
 }

--- a/Crypter.Core/Features/UserSettings/Common.cs
+++ b/Crypter.Core/Features/UserSettings/Common.cs
@@ -90,6 +90,7 @@ internal static class Common
             {
                 x.Name,
                 x.MaximumUploadSize,
+                x.MaximumMessageLength,
                 x.UserQuota,
                 UsedUserSpace = x.DefaultForUserCategory == UserCategory.Anonymous
                     ? dataContext.AnonymousFileTransfers
@@ -124,6 +125,6 @@ internal static class Common
 
         return data is null 
             ? Maybe<GetTransferSettingsResponse>.None
-            : new GetTransferSettingsResponse(data.Name, data.MaximumUploadSize, data.UserQuota - data.UsedUserSpace, data.UsedUserSpace, data.UserQuota, data.FreeTransferQuota - data.UsedFreeTransferSpace, data.UsedFreeTransferSpace, data.FreeTransferQuota);
+            : new GetTransferSettingsResponse(data.Name, data.MaximumUploadSize, data.MaximumMessageLength, data.UserQuota - data.UsedUserSpace, data.UsedUserSpace, data.UserQuota, data.FreeTransferQuota - data.UsedFreeTransferSpace, data.UsedFreeTransferSpace, data.FreeTransferQuota);
     }
 }

--- a/Crypter.DataAccess/Entities/TransferTierEntity.cs
+++ b/Crypter.DataAccess/Entities/TransferTierEntity.cs
@@ -36,6 +36,7 @@ public class TransferTierEntity
     public string Name { get; set; } = null!;
     public string? Description { get; set; }
     public long MaximumUploadSize { get; set; }
+    public int MaximumMessageLength { get; set; }
     public long UserQuota { get; set; }
     public UserCategory? DefaultForUserCategory { get; set; }
 }

--- a/Crypter.DataAccess/Migrations/20250424020928_AddMaximumMessageLengthColumn.Designer.cs
+++ b/Crypter.DataAccess/Migrations/20250424020928_AddMaximumMessageLengthColumn.Designer.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Crypter.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Crypter.DataAccess.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20250424020928_AddMaximumMessageLengthColumn")]
+    partial class AddMaximumMessageLengthColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Crypter.DataAccess/Migrations/20250424020928_AddMaximumMessageLengthColumn.cs
+++ b/Crypter.DataAccess/Migrations/20250424020928_AddMaximumMessageLengthColumn.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Crypter.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMaximumMessageLengthColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MaximumMessageLength",
+                schema: "crypter",
+                table: "TransferTier",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.UpdateData(
+                schema: "crypter",
+                table: "TransferTier",
+                keyColumn: "Id",
+                keyValues: [1, 2, 3],
+                column: "MaximumMessageLength",
+                values: [1024, 4096, 4096]);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaximumMessageLength",
+                schema: "crypter",
+                table: "TransferTier");
+        }
+    }
+}

--- a/Crypter.Web/Shared/Transfer/UploadFileTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/UploadFileTransfer.razor.cs
@@ -56,9 +56,11 @@ public partial class UploadFileTransfer : IDisposable
         _absoluteMaximumBufferSize = ClientTransferSettings.MaximumUploadBufferSizeMB * Convert.ToInt64(Math.Pow(10, 6));
     }
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnParametersSetAsync()
     {
         _currentMaximumUploadSize = await UserTransferSettingsService.GetCurrentMaximumUploadSizeAsync();
+        StateHasChanged();
+        await base.OnParametersSetAsync();
     }
 
     private void HandleDragEnter()

--- a/Crypter.Web/Shared/Transfer/UploadMessageTransfer.razor
+++ b/Crypter.Web/Shared/Transfer/UploadMessageTransfer.razor
@@ -30,13 +30,13 @@
     <div class="row">
         <div class="col-12 p-0 my-3">
             <label>Subject</label>
-            <input type="text" class="form-control" @bind="MessageSubject" @bind:event="oninput" id="messageSubject" name="messageSubject" placeholder="Subject">
+            <input type="text" class="form-control" @bind="_messageSubject" @bind:event="oninput" id="messageSubject" name="messageSubject" placeholder="Subject">
         </div>
         <div class="col-12 p-0">
             <label>Message</label>
-            <textarea class="form-control" @bind="MessageBody" @bind:event="oninput" id="messageText" name="messageText" rows="5" cols="57" placeholder="Type your message here..." maxlength="@_maxMessageLength"></textarea>
+            <textarea class="form-control" @bind="_messageBody" @bind:event="oninput" id="messageText" name="messageText" rows="5" cols="57" placeholder="Type your message here..." maxlength="@_maxMessageLength"></textarea>
             <label>
-                <small class="align-text-bottom">@(_maxMessageLength - MessageBody.Length) remaining</small>
+                <small class="align-text-bottom">@(_maxMessageLength - _messageBody.Length) remaining</small>
             </label>
         </div>
     </div>

--- a/Crypter.Web/Shared/Transfer/UploadMessageTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/UploadMessageTransfer.razor.cs
@@ -39,11 +39,13 @@ public partial class UploadMessageTransfer : IDisposable
     private string _messageBody = string.Empty;
     private int _maxMessageLength = 0;
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnParametersSetAsync()
     {
         long maximumUploadSize = await UserTransferSettingsService.GetCurrentMaximumUploadSizeAsync();
         int maximumMessageLength = await UserTransferSettingsService.GetAbsoluteMaximumMessageLengthAsync();
         _maxMessageLength = Math.Min((int)Math.Min(maximumUploadSize, int.MaxValue), maximumMessageLength);
+        StateHasChanged();
+        await base.OnParametersSetAsync();
     }
 
     private async Task OnEncryptClicked()

--- a/Crypter.Web/Shared/Transfer/UploadMessageTransfer.razor.cs
+++ b/Crypter.Web/Shared/Transfer/UploadMessageTransfer.razor.cs
@@ -25,7 +25,6 @@
  */
 
 using System;
-using System.Reflection.Metadata;
 using System.Threading.Tasks;
 using Crypter.Common.Client.Transfer.Handlers;
 using Crypter.Common.Client.Transfer.Models;
@@ -36,17 +35,24 @@ namespace Crypter.Web.Shared.Transfer;
 
 public partial class UploadMessageTransfer : IDisposable
 {
-    protected string MessageSubject = string.Empty;
-    protected string MessageBody = string.Empty;
-    protected const int _maxMessageLength = 1024;
+    private string _messageSubject = string.Empty;
+    private string _messageBody = string.Empty;
+    private int _maxMessageLength = 0;
 
-    protected async Task OnEncryptClicked()
+    protected override async Task OnInitializedAsync()
+    {
+        long maximumUploadSize = await UserTransferSettingsService.GetCurrentMaximumUploadSizeAsync();
+        int maximumMessageLength = await UserTransferSettingsService.GetAbsoluteMaximumMessageLengthAsync();
+        _maxMessageLength = Math.Min((int)Math.Min(maximumUploadSize, int.MaxValue), maximumMessageLength);
+    }
+
+    private async Task OnEncryptClicked()
     {
         EncryptionInProgress = true;
         ErrorMessage = string.Empty;
 
         await SetProgressMessageAsync("Encrypting message");
-        UploadMessageHandler messageUploader = TransferHandlerFactory.CreateUploadMessageHandler(MessageSubject, MessageBody, ExpirationHours);
+        UploadMessageHandler messageUploader = TransferHandlerFactory.CreateUploadMessageHandler(_messageSubject, _messageBody, ExpirationHours);
 
         SetHandlerUserInfo(messageUploader);
         Either<UploadTransferError, UploadHandlerResponse> uploadResponse = await messageUploader.UploadAsync();
@@ -54,7 +60,7 @@ public partial class UploadMessageTransfer : IDisposable
         Dispose();
     }
 
-    protected async Task SetProgressMessageAsync(string message)
+    private async Task SetProgressMessageAsync(string message)
     {
         UploadStatusMessage = message;
         StateHasChanged();
@@ -63,8 +69,8 @@ public partial class UploadMessageTransfer : IDisposable
 
     public void Dispose()
     {
-        MessageSubject = string.Empty;
-        MessageBody = string.Empty;
+        _messageSubject = string.Empty;
+        _messageBody = string.Empty;
         EncryptionInProgress = false;
         GC.SuppressFinalize(this);
     }


### PR DESCRIPTION
Stop hard-coding the maximum message length.  Make the maximum message length configurable using the same TransferTier data as file uploads.

Tests
- [x] Test file uploads (make sure the 'current' maximum upload size is observed by the client)
- [x] Test message uploads