### PR TITLE
Skip build and test workflows for documentation-only changes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,8 +7,13 @@ on:
     - cron: '15 3 * * 2'
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-code-changes.yml
+
   analyze:
     name: Analyze
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/detect-code-changes.yml
+++ b/.github/workflows/detect-code-changes.yml
@@ -1,0 +1,53 @@
+name: Detect code changes
+
+on:
+  workflow_call:
+    outputs:
+      code:
+        description: 'true when the event touches anything other than documentation'
+        value: ${{ jobs.detect.outputs.code }}
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    outputs:
+      code: ${{ steps.detect.outputs.code }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect code changes
+        id: detect
+        env:
+          event_name: ${{ github.event_name }}
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          head_sha: ${{ github.event.pull_request.head.sha }}
+          documentation: '(\.md$|^Documentation/|^\.github/ISSUE_TEMPLATE/)'
+        run: |
+          set -euo pipefail
+
+          # Only a pull request has a diff to classify. Anything else, such as
+          # the scheduled CodeQL analysis, has to assume code is in scope.
+          if [ "$event_name" != 'pull_request' ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "$base_sha...$head_sha")"
+          echo "Changed files:"
+          echo "$changed_files"
+
+          # An empty diff falls through to 'true' so that an undetectable
+          # change never silently skips a required check.
+          if [ -n "$changed_files" ] && ! echo "$changed_files" | grep -qvE "$documentation"; then
+            echo "Documentation only."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/pr-build-api.yml
+++ b/.github/workflows/pr-build-api.yml
@@ -5,8 +5,13 @@ on:
     branches: [ main, stable ]
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-code-changes.yml
+
   build-api:
 
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-build-web.yml
+++ b/.github/workflows/pr-build-web.yml
@@ -5,8 +5,13 @@ on:
     branches: [ main, stable ]
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-code-changes.yml
+
   build-web:
 
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,7 +5,12 @@ on:
     branches: [ main, stable ]
 
 jobs:
+  changes:
+    uses: ./.github/workflows/detect-code-changes.yml
+
   build-and-test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -30,6 +35,8 @@ jobs:
         run: dotnet test Crypter.Test --configuration Release --no-build --verbosity normal
 
   build-and-test-web:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Documentation-only pull requests were running the API and Web image builds, both unit test jobs, and CodeQL. Now they don't.

A new reusable workflow, `detect-code-changes.yml`, diffs the pull request against its base and outputs whether anything outside documentation changed. `pr-build-api`, `pr-build-web`, `unit-test` and `codeql-analysis` call it and gate their jobs on the result. Documentation means `*.md`, anything under `Documentation/`, and `.github/ISSUE_TEMPLATE/`; everything else, including workflow and `.csproj` changes, counts as code.

Since Build and Test are required status checks, this gates jobs with an `if` condition rather than filtering the trigger with `paths-ignore` — a skipped job reports success, but a workflow that never starts leaves its check pending and blocks the merge.

Events with no pull request diff to inspect, such as the scheduled CodeQL run, are treated as code changes and run everything.
