### PR TITLE
Add monad assertions to the test project

### DIFF
--- a/Crypter.Test/Assert.cs
+++ b/Crypter.Test/Assert.cs
@@ -48,7 +48,7 @@ internal abstract class Assert : NUnit.Framework.Assert
     {
         if (maybe.IsNone)
         {
-            Fail($"Expected Some, but was {Describe(maybe)}.");
+            throw new AssertionException($"Expected Some, but was {Describe(maybe)}.");
         }
 
         return maybe.SomeOrDefault()!;
@@ -83,7 +83,7 @@ internal abstract class Assert : NUnit.Framework.Assert
     {
         if (!either.IsRight)
         {
-            Fail($"Expected Right, but was {Describe(either)}.");
+            throw new AssertionException($"Expected Right, but was {Describe(either)}.");
         }
 
         return either.RightOrDefault(default!)!;
@@ -107,7 +107,7 @@ internal abstract class Assert : NUnit.Framework.Assert
     {
         if (!either.IsLeft)
         {
-            Fail($"Expected Left, but was {Describe(either)}.");
+            throw new AssertionException($"Expected Left, but was {Describe(either)}.");
         }
 
         return either.LeftOrDefault(default!)!;

--- a/Crypter.Test/Assert.cs
+++ b/Crypter.Test/Assert.cs
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2026 Crypter File Transfer
+ *
+ * This file is part of the Crypter file transfer project.
+ *
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ *
+ * Contact the current copyright holder to discuss commercial license options.
+ */
+
+using System.Threading.Tasks;
+using EasyMonads;
+using NUnit.Framework;
+
+namespace Crypter.Test;
+
+/// <summary>
+/// NUnit's assertions plus assertions for <see cref="Maybe{T}"/> and <see cref="Either{TLeft,TRight}"/>.
+/// </summary>
+/// <remarks>
+/// This type shadows <see cref="NUnit.Framework.Assert"/> for every test in the Crypter.Test namespace,
+/// so the inherited assertions are reached through the same <c>Assert</c> name they always were.
+/// The monad assertions return the matched value, which lets a test assert the state and bind the
+/// value in one statement.
+/// </remarks>
+internal abstract class Assert : NUnit.Framework.Assert
+{
+    /// <summary>
+    /// Assert that the maybe is in the Some state and return the value it holds.
+    /// </summary>
+    internal static T IsSome<T>(Maybe<T> maybe)
+    {
+        if (maybe.IsNone)
+        {
+            Fail($"Expected Some, but was {Describe(maybe)}.");
+        }
+
+        return maybe.SomeOrDefault()!;
+    }
+
+    /// <summary>
+    /// Assert that the maybe is in the Some state and holds <paramref name="expectedValue"/>, then
+    /// return the value it holds.
+    /// </summary>
+    internal static T IsSome<T>(Maybe<T> maybe, T expectedValue)
+    {
+        T value = IsSome(maybe);
+        That(value, Is.EqualTo(expectedValue));
+        return value;
+    }
+
+    /// <summary>
+    /// Assert that the maybe is in the None state.
+    /// </summary>
+    internal static void IsNone<T>(Maybe<T> maybe)
+    {
+        if (maybe.IsSome)
+        {
+            Fail($"Expected None, but was {Describe(maybe)}.");
+        }
+    }
+
+    /// <summary>
+    /// Assert that the either is in the Right state and return the value it holds.
+    /// </summary>
+    internal static TRight IsRight<TLeft, TRight>(Either<TLeft, TRight> either)
+    {
+        if (!either.IsRight)
+        {
+            Fail($"Expected Right, but was {Describe(either)}.");
+        }
+
+        return either.RightOrDefault(default!)!;
+    }
+
+    /// <summary>
+    /// Assert that the either is in the Right state and holds <paramref name="expectedValue"/>, then
+    /// return the value it holds.
+    /// </summary>
+    internal static TRight IsRight<TLeft, TRight>(Either<TLeft, TRight> either, TRight expectedValue)
+    {
+        TRight value = IsRight(either);
+        That(value, Is.EqualTo(expectedValue));
+        return value;
+    }
+
+    /// <summary>
+    /// Assert that the either is in the Left state and return the value it holds.
+    /// </summary>
+    internal static TLeft IsLeft<TLeft, TRight>(Either<TLeft, TRight> either)
+    {
+        if (!either.IsLeft)
+        {
+            Fail($"Expected Left, but was {Describe(either)}.");
+        }
+
+        return either.LeftOrDefault(default!)!;
+    }
+
+    /// <summary>
+    /// Assert that the either is in the Left state and holds <paramref name="expectedValue"/>, then
+    /// return the value it holds.
+    /// </summary>
+    internal static TLeft IsLeft<TLeft, TRight>(Either<TLeft, TRight> either, TLeft expectedValue)
+    {
+        TLeft value = IsLeft(either);
+        That(value, Is.EqualTo(expectedValue));
+        return value;
+    }
+
+    /// <summary>
+    /// Assert that the either is in the Neither state.
+    /// </summary>
+    internal static void IsNeither<TLeft, TRight>(Either<TLeft, TRight> either)
+    {
+        if (!either.IsNeither)
+        {
+            Fail($"Expected Neither, but was {Describe(either)}.");
+        }
+    }
+
+    /// <summary>
+    /// Await the task, then assert that the maybe is in the Some state and return the value it holds.
+    /// </summary>
+    internal static async Task<T> IsSomeAsync<T>(Task<Maybe<T>> maybeTask)
+    {
+        return IsSome(await maybeTask);
+    }
+
+    /// <summary>
+    /// Await the task, then assert that the maybe is in the Some state and holds
+    /// <paramref name="expectedValue"/>, then return the value it holds.
+    /// </summary>
+    internal static async Task<T> IsSomeAsync<T>(Task<Maybe<T>> maybeTask, T expectedValue)
+    {
+        return IsSome(await maybeTask, expectedValue);
+    }
+
+    /// <summary>
+    /// Await the task, then assert that the maybe is in the None state.
+    /// </summary>
+    internal static async Task IsNoneAsync<T>(Task<Maybe<T>> maybeTask)
+    {
+        IsNone(await maybeTask);
+    }
+
+    /// <summary>
+    /// Await the task, then assert that the either is in the Right state and return the value it holds.
+    /// </summary>
+    internal static async Task<TRight> IsRightAsync<TLeft, TRight>(Task<Either<TLeft, TRight>> eitherTask)
+    {
+        return IsRight(await eitherTask);
+    }
+
+    /// <summary>
+    /// Await the task, then assert that the either is in the Right state and holds
+    /// <paramref name="expectedValue"/>, then return the value it holds.
+    /// </summary>
+    internal static async Task<TRight> IsRightAsync<TLeft, TRight>(Task<Either<TLeft, TRight>> eitherTask, TRight expectedValue)
+    {
+        return IsRight(await eitherTask, expectedValue);
+    }
+
+    /// <summary>
+    /// Await the task, then assert that the either is in the Left state and return the value it holds.
+    /// </summary>
+    internal static async Task<TLeft> IsLeftAsync<TLeft, TRight>(Task<Either<TLeft, TRight>> eitherTask)
+    {
+        return IsLeft(await eitherTask);
+    }
+
+    /// <summary>
+    /// Await the task, then assert that the either is in the Left state and holds
+    /// <paramref name="expectedValue"/>, then return the value it holds.
+    /// </summary>
+    internal static async Task<TLeft> IsLeftAsync<TLeft, TRight>(Task<Either<TLeft, TRight>> eitherTask, TLeft expectedValue)
+    {
+        return IsLeft(await eitherTask, expectedValue);
+    }
+
+    /// <summary>
+    /// Await the task, then assert that the either is in the Neither state.
+    /// </summary>
+    internal static async Task IsNeitherAsync<TLeft, TRight>(Task<Either<TLeft, TRight>> eitherTask)
+    {
+        IsNeither(await eitherTask);
+    }
+
+    private static string Describe<T>(Maybe<T> maybe)
+    {
+        return maybe.IsSome
+            ? $"Some({maybe.SomeOrDefault()})"
+            : "None";
+    }
+
+    private static string Describe<TLeft, TRight>(Either<TLeft, TRight> either)
+    {
+        if (either.IsRight)
+        {
+            return $"Right({either.RightOrDefault(default!)})";
+        }
+
+        return either.IsLeft
+            ? $"Left({either.LeftOrDefault(default!)})"
+            : "Neither";
+    }
+}

--- a/Crypter.Test/Common_Tests/Assert_Tests.cs
+++ b/Crypter.Test/Common_Tests/Assert_Tests.cs
@@ -110,6 +110,13 @@ internal class Assert_Tests
     }
 
     [Test]
+    public void Is_Right_Fails_For_Neither()
+    {
+        AssertionException? exception = Assert.Throws<AssertionException>(() => Assert.IsRight(Neither));
+        Assert.That(exception!.Message, Is.EqualTo("Expected Right, but was Neither."));
+    }
+
+    [Test]
     public void Is_Right_With_An_Expected_Value_Returns_The_Value()
     {
         string value = Assert.IsRight(Right, SomeValue);
@@ -137,6 +144,13 @@ internal class Assert_Tests
     }
 
     [Test]
+    public void Is_Left_Fails_For_Neither()
+    {
+        AssertionException? exception = Assert.Throws<AssertionException>(() => Assert.IsLeft(Neither));
+        Assert.That(exception!.Message, Is.EqualTo("Expected Left, but was Neither."));
+    }
+
+    [Test]
     public void Is_Left_With_An_Expected_Value_Returns_The_Value()
     {
         int value = Assert.IsLeft(Left, LeftValue);
@@ -160,6 +174,48 @@ internal class Assert_Tests
     {
         AssertionException? exception = Assert.Throws<AssertionException>(() => Assert.IsNeither(Right));
         Assert.That(exception!.Message, Is.EqualTo($"Expected Neither, but was Right({SomeValue})."));
+    }
+
+    [Test]
+    public void Is_Some_Inside_A_Multiple_Scope_Does_Not_Return_A_Value()
+    {
+        bool returned = false;
+
+        Assert.Throws<AssertionException>(() => Assert.Multiple(() =>
+        {
+            _ = Assert.IsSome(None);
+            returned = true;
+        }));
+
+        Assert.That(returned, Is.False);
+    }
+
+    [Test]
+    public void Is_Right_Inside_A_Multiple_Scope_Does_Not_Return_A_Value()
+    {
+        bool returned = false;
+
+        Assert.Throws<AssertionException>(() => Assert.Multiple(() =>
+        {
+            _ = Assert.IsRight(Left);
+            returned = true;
+        }));
+
+        Assert.That(returned, Is.False);
+    }
+
+    [Test]
+    public void Is_Left_Inside_A_Multiple_Scope_Does_Not_Return_A_Value()
+    {
+        bool returned = false;
+
+        Assert.Throws<AssertionException>(() => Assert.Multiple(() =>
+        {
+            _ = Assert.IsLeft(Right);
+            returned = true;
+        }));
+
+        Assert.That(returned, Is.False);
     }
 
     [Test]

--- a/Crypter.Test/Common_Tests/Assert_Tests.cs
+++ b/Crypter.Test/Common_Tests/Assert_Tests.cs
@@ -1,0 +1,276 @@
+/*
+ * Copyright (C) 2026 Crypter File Transfer
+ *
+ * This file is part of the Crypter file transfer project.
+ *
+ * Crypter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Crypter source code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the aforementioned license
+ * by purchasing a commercial license. Buying such a license is mandatory
+ * as soon as you develop commercial activities involving the Crypter source
+ * code without disclosing the source code of your own applications.
+ *
+ * Contact the current copyright holder to discuss commercial license options.
+ */
+
+using System.Threading.Tasks;
+using EasyMonads;
+using NUnit.Framework;
+
+namespace Crypter.Test.Common_Tests;
+
+/// <summary>
+/// Every monad assertion is exercised twice: once against the state it expects, and once against a
+/// state it must reject. A helper that never fails would silently pass every test that depends on it.
+/// </summary>
+/// <remarks>
+/// The rejection tests wrap the assertion in <c>Assert.Throws</c> rather than a try/catch. NUnit
+/// records a failed assertion against the running test as soon as it happens, and only
+/// <c>Assert.Throws</c> clears that record. A caught <see cref="AssertionException"/> still fails the
+/// test.
+/// </remarks>
+[TestFixture]
+internal class Assert_Tests
+{
+    private const string SomeValue = "Frodo";
+    private const string OtherValue = "Bilbo";
+    private const int LeftValue = 42;
+    private const int OtherLeftValue = 24;
+
+    private static Maybe<string> Some => Maybe<string>.From(SomeValue);
+    private static Maybe<string> None => Maybe<string>.None;
+
+    private static Either<int, string> Right => Either<int, string>.FromRight(SomeValue);
+    private static Either<int, string> Left => Either<int, string>.FromLeft(LeftValue);
+    private static Either<int, string> Neither => Either<int, string>.Neither;
+
+    [Test]
+    public void Is_Some_Returns_The_Value()
+    {
+        string value = Assert.IsSome(Some);
+        Assert.That(value, Is.EqualTo(SomeValue));
+    }
+
+    [Test]
+    public void Is_Some_Fails_For_None()
+    {
+        AssertionException? exception = Assert.Throws<AssertionException>(() => Assert.IsSome(None));
+        Assert.That(exception!.Message, Is.EqualTo("Expected Some, but was None."));
+    }
+
+    [Test]
+    public void Is_Some_With_An_Expected_Value_Returns_The_Value()
+    {
+        string value = Assert.IsSome(Some, SomeValue);
+        Assert.That(value, Is.EqualTo(SomeValue));
+    }
+
+    [Test]
+    public void Is_Some_With_An_Expected_Value_Fails_For_A_Different_Value()
+    {
+        Assert.Throws<AssertionException>(() => Assert.IsSome(Some, OtherValue));
+    }
+
+    [Test]
+    public void Is_None_Passes_For_None()
+    {
+        Assert.IsNone(None);
+    }
+
+    [Test]
+    public void Is_None_Fails_For_Some()
+    {
+        AssertionException? exception = Assert.Throws<AssertionException>(() => Assert.IsNone(Some));
+        Assert.That(exception!.Message, Is.EqualTo($"Expected None, but was Some({SomeValue})."));
+    }
+
+    [Test]
+    public void Is_Right_Returns_The_Value()
+    {
+        string value = Assert.IsRight(Right);
+        Assert.That(value, Is.EqualTo(SomeValue));
+    }
+
+    [Test]
+    public void Is_Right_Fails_For_Left()
+    {
+        AssertionException? exception = Assert.Throws<AssertionException>(() => Assert.IsRight(Left));
+        Assert.That(exception!.Message, Is.EqualTo($"Expected Right, but was Left({LeftValue})."));
+    }
+
+    [Test]
+    public void Is_Right_With_An_Expected_Value_Returns_The_Value()
+    {
+        string value = Assert.IsRight(Right, SomeValue);
+        Assert.That(value, Is.EqualTo(SomeValue));
+    }
+
+    [Test]
+    public void Is_Right_With_An_Expected_Value_Fails_For_A_Different_Value()
+    {
+        Assert.Throws<AssertionException>(() => Assert.IsRight(Right, OtherValue));
+    }
+
+    [Test]
+    public void Is_Left_Returns_The_Value()
+    {
+        int value = Assert.IsLeft(Left);
+        Assert.That(value, Is.EqualTo(LeftValue));
+    }
+
+    [Test]
+    public void Is_Left_Fails_For_Right()
+    {
+        AssertionException? exception = Assert.Throws<AssertionException>(() => Assert.IsLeft(Right));
+        Assert.That(exception!.Message, Is.EqualTo($"Expected Left, but was Right({SomeValue})."));
+    }
+
+    [Test]
+    public void Is_Left_With_An_Expected_Value_Returns_The_Value()
+    {
+        int value = Assert.IsLeft(Left, LeftValue);
+        Assert.That(value, Is.EqualTo(LeftValue));
+    }
+
+    [Test]
+    public void Is_Left_With_An_Expected_Value_Fails_For_A_Different_Value()
+    {
+        Assert.Throws<AssertionException>(() => Assert.IsLeft(Left, OtherLeftValue));
+    }
+
+    [Test]
+    public void Is_Neither_Passes_For_Neither()
+    {
+        Assert.IsNeither(Neither);
+    }
+
+    [Test]
+    public void Is_Neither_Fails_For_Right()
+    {
+        AssertionException? exception = Assert.Throws<AssertionException>(() => Assert.IsNeither(Right));
+        Assert.That(exception!.Message, Is.EqualTo($"Expected Neither, but was Right({SomeValue})."));
+    }
+
+    [Test]
+    public async Task Is_Some_Async_Returns_The_Value_Async()
+    {
+        string value = await Assert.IsSomeAsync(Task.FromResult(Some));
+        Assert.That(value, Is.EqualTo(SomeValue));
+    }
+
+    [Test]
+    public void Is_Some_Async_Fails_For_None()
+    {
+        AssertionException? exception =
+            Assert.ThrowsAsync<AssertionException>(() => Assert.IsSomeAsync(Task.FromResult(None)));
+        Assert.That(exception!.Message, Is.EqualTo("Expected Some, but was None."));
+    }
+
+    [Test]
+    public async Task Is_Some_Async_With_An_Expected_Value_Returns_The_Value_Async()
+    {
+        string value = await Assert.IsSomeAsync(Task.FromResult(Some), SomeValue);
+        Assert.That(value, Is.EqualTo(SomeValue));
+    }
+
+    [Test]
+    public void Is_Some_Async_With_An_Expected_Value_Fails_For_A_Different_Value()
+    {
+        Assert.ThrowsAsync<AssertionException>(() => Assert.IsSomeAsync(Task.FromResult(Some), OtherValue));
+    }
+
+    [Test]
+    public async Task Is_None_Async_Passes_For_None_Async()
+    {
+        await Assert.IsNoneAsync(Task.FromResult(None));
+    }
+
+    [Test]
+    public void Is_None_Async_Fails_For_Some()
+    {
+        AssertionException? exception =
+            Assert.ThrowsAsync<AssertionException>(() => Assert.IsNoneAsync(Task.FromResult(Some)));
+        Assert.That(exception!.Message, Is.EqualTo($"Expected None, but was Some({SomeValue})."));
+    }
+
+    [Test]
+    public async Task Is_Right_Async_Returns_The_Value_Async()
+    {
+        string value = await Assert.IsRightAsync(Task.FromResult(Right));
+        Assert.That(value, Is.EqualTo(SomeValue));
+    }
+
+    [Test]
+    public void Is_Right_Async_Fails_For_Left()
+    {
+        AssertionException? exception =
+            Assert.ThrowsAsync<AssertionException>(() => Assert.IsRightAsync(Task.FromResult(Left)));
+        Assert.That(exception!.Message, Is.EqualTo($"Expected Right, but was Left({LeftValue})."));
+    }
+
+    [Test]
+    public async Task Is_Right_Async_With_An_Expected_Value_Returns_The_Value_Async()
+    {
+        string value = await Assert.IsRightAsync(Task.FromResult(Right), SomeValue);
+        Assert.That(value, Is.EqualTo(SomeValue));
+    }
+
+    [Test]
+    public void Is_Right_Async_With_An_Expected_Value_Fails_For_A_Different_Value()
+    {
+        Assert.ThrowsAsync<AssertionException>(() => Assert.IsRightAsync(Task.FromResult(Right), OtherValue));
+    }
+
+    [Test]
+    public async Task Is_Left_Async_Returns_The_Value_Async()
+    {
+        int value = await Assert.IsLeftAsync(Task.FromResult(Left));
+        Assert.That(value, Is.EqualTo(LeftValue));
+    }
+
+    [Test]
+    public void Is_Left_Async_Fails_For_Right()
+    {
+        AssertionException? exception =
+            Assert.ThrowsAsync<AssertionException>(() => Assert.IsLeftAsync(Task.FromResult(Right)));
+        Assert.That(exception!.Message, Is.EqualTo($"Expected Left, but was Right({SomeValue})."));
+    }
+
+    [Test]
+    public async Task Is_Left_Async_With_An_Expected_Value_Returns_The_Value_Async()
+    {
+        int value = await Assert.IsLeftAsync(Task.FromResult(Left), LeftValue);
+        Assert.That(value, Is.EqualTo(LeftValue));
+    }
+
+    [Test]
+    public void Is_Left_Async_With_An_Expected_Value_Fails_For_A_Different_Value()
+    {
+        Assert.ThrowsAsync<AssertionException>(() => Assert.IsLeftAsync(Task.FromResult(Left), OtherLeftValue));
+    }
+
+    [Test]
+    public async Task Is_Neither_Async_Passes_For_Neither_Async()
+    {
+        await Assert.IsNeitherAsync(Task.FromResult(Neither));
+    }
+
+    [Test]
+    public void Is_Neither_Async_Fails_For_Left()
+    {
+        AssertionException? exception =
+            Assert.ThrowsAsync<AssertionException>(() => Assert.IsNeitherAsync(Task.FromResult(Left)));
+        Assert.That(exception!.Message, Is.EqualTo($"Expected Neither, but was Left({LeftValue})."));
+    }
+}


### PR DESCRIPTION
Adds `Assert.IsSome`, `IsNone`, `IsRight`, `IsLeft`, and `IsNeither` for `Maybe` and `Either`, each with an overload taking an expected value and an `Async` variant taking the task directly. The ones that match a value return it, so a test can assert the state and bind the value in one statement, and the failure messages name the actual state and its payload.

`Assert` here is a subclass of NUnit's, declared in the `Crypter.Test` namespace. Unqualified `Assert` in a test now resolves to it and reaches the inherited assertions by the same name. No existing assertions were changed.

The assertions that return a value throw on the wrong state rather than calling `Fail`. Inside an `Assert.Multiple` scope `Fail` records the failure and returns, which would leave them handing back a default value for the test to bind and dereference. `IsNone` and `IsNeither` call `Fail`, so a multiple scope still collects them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)