### PR TITLE
Push pipeline branches to the org repository

### DIFF
--- a/.claude/agents/ci-watcher.md
+++ b/.claude/agents/ci-watcher.md
@@ -41,9 +41,8 @@ git -C <repo> rev-parse <branch>
 ```
 
 Compare that against the head SHA in the pull request data. A push takes a moment to register,
-so poll `get_check_runs` every 30 seconds until runs appear. If nothing has appeared after a
-few minutes, say so and stop: on a fork, workflows stay disabled until they are enabled once in
-the Actions tab, and that is a setup problem no amount of waiting fixes.
+so poll `get_check_runs` until runs appear. If nothing has appeared after a few minutes, say so
+and stop: a push that starts no checks is a setup problem no amount of waiting fixes.
 
 ## Watch
 

--- a/.claude/skills/crypter-change/SKILL.md
+++ b/.claude/skills/crypter-change/SKILL.md
@@ -119,16 +119,13 @@ the same way twice, a failure the plan did not anticipate, or anything that read
 rather than wrong code. Three attempts is a limit, not a quota to spend.
 
 Stop immediately, without spending an attempt, where `ci-watcher` reports that no run appeared
-for the commit. Workflows stay disabled on a new fork until they are enabled once in its Actions
-tab, and that is a setup problem.
+for the commit. Nothing to fix has been established yet, and a push that starts no checks is a
+setup problem rather than a code one.
 
 ## 8. Report
 
-- The fork pull request URL and whether its checks are green. It is a draft; taking it out of
-  draft is the user's.
+- The pull request URL and whether its checks are green. It is a draft; taking it out of draft
+  is the user's.
 - What each fix attempt changed, where any ran.
 - Anything the implementer could not do, and any drift the auditor flagged.
 - What you rejected in triage that the user might disagree with, and where `triage.md` is.
-
-The upstream pull request is a separate one against `Crypter-File-Transfer/Crypter`, since the
-base repository is fixed when a pull request is created. The description is ready to paste.

--- a/.claude/skills/crypter-step-open-pull-request/SKILL.md
+++ b/.claude/skills/crypter-step-open-pull-request/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: crypter-step-open-pull-request
-description: Push a branch the pipeline built in the container to the fork and open or update its draft pull request. Invoked as /crypter-step-open-pull-request {run-id} {branch} by the crypter-change and crypter-triage-review skills.
+description: Push a branch the pipeline built in the container to the repository and open or update its draft pull request. Invoked as /crypter-step-open-pull-request {run-id} {branch} by the crypter-change and crypter-triage-review skills.
 ---
 
 # Crypter step open pull request
 
-Take the branch the container built and put it on the fork, with a draft pull request open
+Take the branch the container built and put it on the repository, with a draft pull request open
 against it.
 
 Safe to run repeatedly on the same branch. Each run pushes whatever commits the container has
@@ -25,30 +25,37 @@ git -c protocol.ext.allow=user fetch \
 `protocol.ext.allow` is passed per command and stays out of your config. **If this fails, stop
 and say so** — the branch is the whole deliverable.
 
-## 2. Push to the fork
+## 2. Push to the repository
+
+`origin` is the org repository, the same one the container cloned and the same one the pull
+request opens against. Confirm that before pushing anything:
 
 ```bash
-git fetch upstream
-git push origin upstream/stable:refs/heads/stable
-git push origin {branch}
+git remote get-url origin
 ```
 
-The first push keeps the fork's `stable` level with the org repository, so the pull request
-compares against current code.
+**If it is not `Crypter-File-Transfer/Crypter`, stop and say so.** A checkout wired up
+differently — a fork on `origin`, or the org on some other remote — pushes the branch somewhere
+the pull request will not find it.
+
+```bash
+git fetch origin
+git push origin {branch}
+```
 
 ## 3. Open or update the pull request
 
 Where a pull request for `{branch}` is already open, the push has updated it and there is
 nothing more to do. Say which one it was.
 
-Otherwise open it against the fork, base `stable`, as a draft, using whatever GitHub access this
-session has — the `gh` CLI, or the GitHub MCP server's `create_pull_request`.
+Otherwise open it against `Crypter-File-Transfer/Crypter`, base `stable`, as a draft, using
+whatever GitHub access this session has — the `gh` CLI, or the GitHub MCP server's
+`create_pull_request`.
 
 It stays a draft. Taking it out of draft is the user's.
 
 Take the title and description from the report of whoever built the branch. Write the
-description for the org repository's reviewers, since it carries over when the upstream pull
-request is opened.
+description for the reviewers who will read it on that pull request.
 
 ## 4. Report
 

--- a/.claude/skills/crypter-step-plan/SKILL.md
+++ b/.claude/skills/crypter-step-plan/SKILL.md
@@ -18,11 +18,10 @@ it goes to `crypter-change`, to a person, or nowhere.
 ## 1. Sync
 
 ```bash
-git fetch upstream
 git fetch origin
 ```
 
-Read the code at `upstream/stable`, the commit a build branches from.
+Read the code at `origin/stable`, the commit a build branches from.
 
 ## 2. Understand before deciding
 

--- a/Documentation/Development/Agentic Development Pipeline.md
+++ b/Documentation/Development/Agentic Development Pipeline.md
@@ -45,8 +45,15 @@ uncommitted work on your machine.
 The container does hold your Claude Code credential, in the `crypter-pipeline-claude` volume,
 and its network egress is open. Treat it as a trust boundary rather than a sandbox.
 
-When `/crypter-change` finishes you have a fork pull request to read; opening one against the org
-repository is something you do by hand afterwards.
+The branch is pushed to the org repository and the pull request opens against it, base `stable`,
+the same route a branch of your own takes. `/crypter-change` leaves you a draft pull request to
+read.
+
+The org repository therefore has two names in this pipeline. Your session reaches it as `origin`,
+the remote your checkout already has. The container reaches it as `upstream`, the name its clone
+gives the one remote it has, chosen so that a remote with no push url reads as one. Host-side
+skills say `origin` and container-side skills say `upstream`; both mean
+`Crypter-File-Transfer/Crypter`.
 
 This document covers the setup you need before the container will start.
 
@@ -137,14 +144,6 @@ into.
 
 Swap `up -d` for `down` to stop it. The named volumes outlive the container, so the next `up`
 reuses the workspace and your Claude Code credentials.
-
-## Enable Actions on your fork
-
-GitHub disables workflows on new forks. Until you turn them on, pushing a branch runs nothing,
-and `/crypter-change` stops at the CI stage reporting that no run ever appeared.
-
-Open the **Actions** tab on your fork and use the button confirming you want to run workflows.
-You only do this once.
 
 ## What is in the container
 


### PR DESCRIPTION
The pipeline skills assumed `origin` was a personal fork and `upstream` the org repository. A checkout with one `origin` remote pointing at the org fails on `crypter-step-plan`'s first command, and the push step has no `upstream/stable` to sync a fork from.

Branches now go to the org repository directly. That removes the fork sync push and the second pull request that had to be opened by hand afterwards, so a `/crypter-change` run ends at one draft pull request. `crypter-step-open-pull-request` checks `origin` before it pushes.

Container-side skills keep `upstream` — that is the name the container's own clone gives its single read-only remote, and it is unaffected by this. The pipeline doc now says so, since the same repository having two names across the boundary is otherwise a trap.

The doc also loses its "Enable Actions on your fork" section, which no longer applies.
