### PR TITLE
Split the reviewer conventions across the lenses that own them

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -47,17 +47,10 @@ nits, and the nits make the real ones harder to see.
 
 ## Crypter's conventions are in scope
 
-A change that ignores them is a legitimate finding for any lens:
-
-- Nulls or exceptions where `Maybe<T>` or `Either<TLeft, TRight>` from `Crypter.Common/Monads`
-  belongs.
-- Raw strings where a validated type from `Crypter.Common/Primitives` exists.
-- Sync IO on a database, file, or network path; a missing `Async` suffix.
-- Object initializers where a constructor belongs; magic strings where an enum belongs.
-- An entity change under `Crypter.DataAccess/Entities` with no migration in
-  `Crypter.DataAccess/Migrations` — and whether it needs a companion script in
-  `Crypter.DataAccess/Scripts`.
-- Comments narrating history rather than explaining the code as it stands.
+A change that ignores the conventions in `CLAUDE.md` and the Coding Standard is a legitimate
+finding, and your lens names the ones that are yours. They are split across the lenses by what
+goes wrong when they are broken, so a convention yours does not name is another lens's — leave
+it, the same as anything else outside your brief.
 
 ## Report
 

--- a/.claude/skills/crypter-devcontainer-examine/SKILL.md
+++ b/.claude/skills/crypter-devcontainer-examine/SKILL.md
@@ -62,16 +62,41 @@ Given a plan path, invoke `conformance-auditor` with it, the workspace, the base
 ## 3. Code review
 
 Invoke `reviewer` once per lens, in parallel — they do not interact. Each gets the workspace, the
-base ref, and `/runs/{run-id}/findings/{lens}.md`.
+base ref, `/runs/{run-id}/findings/{lens}.md`, and its brief below, in full.
 
-| Lens | Brief |
-|---|---|
-| correctness | Bugs, boundary conditions, error paths, and what happens when inputs are hostile or absent. |
-| maintainability | Readability, scope creep, and the conventions in `CLAUDE.md` and the Coding Standard. |
-| testability | What the tests pin down, what they leave unverified, and whether the change can be tested at all. |
-| security | Crypto boundaries, input validation, authentication and authorisation paths, key handling, transfer integrity. |
+A brief is the whole of what its lens covers, conventions included. The conventions are split by
+what goes wrong when they are broken rather than kept as one list, so that a lens is told the
+ones it can judge the consequences of and left ignorant of the rest.
 
-Adding a lens means adding a row here. The `reviewer` definition stays as it is; the lens comes
+**correctness** — Bugs, boundary conditions, error paths, and what happens when inputs are
+hostile or absent. Including:
+
+- Nulls or exceptions where `Maybe<T>` or `Either<TLeft, TRight>` from `Crypter.Common/Monads`
+  belongs, and the crash or swallowed failure that follows.
+- Sync IO on a database, file, or network path.
+- Object initializers where a constructor belongs, leaving an object usable before it is whole.
+- Magic strings where an enum belongs.
+- An entity change under `Crypter.DataAccess/Entities` with no migration in
+  `Crypter.DataAccess/Migrations`, and whether it needs a companion script in
+  `Crypter.DataAccess/Scripts`.
+
+**maintainability** — Readability, scope creep, and the conventions in `CLAUDE.md` and the Coding
+Standard that no other lens claims. Including:
+
+- Comments narrating history rather than explaining the code as it stands.
+- A missing `Async` suffix on an async method. The naming is yours; sync IO on a path that should
+  be async belongs to correctness.
+
+**testability** — What the tests pin down, what they leave unverified, and whether the change can
+be tested at all.
+
+**security** — Crypto boundaries, input validation, authentication and authorisation paths, key
+handling, transfer integrity. Including:
+
+- Raw strings where a validated type from `Crypter.Common/Primitives` exists, and the unchecked
+  value that reaches past a boundary as a result.
+
+Adding a lens means adding a brief here. The `reviewer` definition stays as it is; the lens comes
 from the prompt.
 
 Run the phases in parallel with each other too. The auditor and the reviewers read the same diff


### PR DESCRIPTION
The `reviewer` agent gave every lens the same list of Crypter conventions while also telling it to stay inside its lens. The security lens was primed to report a missing `Async` suffix and forbidden from reporting it at the same time, and nothing decided which instruction won.

The conventions are now split by what goes wrong when they are broken, and each part sits in the lens brief that can judge that consequence: monads, sync IO, constructors, enums and missing migrations under correctness; history-narrating comments and `Async` naming under maintainability; validated primitives under security. Testability claims none.

The list moves out of `.claude/agents/reviewer.md` and into the lens briefs in `crypter-devcontainer-examine`, so the agent definition stays lens-agnostic. The lens table became four prose briefs because the conventions do not fit in a table cell.

Worth knowing: the briefs now have to reach each reviewer in full. A caller that paraphrases one drops the conventions under it silently.
