### PR TITLE
Build Crypter.Web on Node 26

### DIFF
--- a/Crypter.Web/Dockerfile
+++ b/Crypter.Web/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /source/
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update -yq && apt-get upgrade -yq && apt-get install -yq curl git nano
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt-get install -yq nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_26.x | bash - && apt-get install -yq nodejs
 RUN npm install --global pnpm@11.18.0 \
     && SHELL=bash pnpm setup \
     && source /root/.bashrc


### PR DESCRIPTION
The web image installs Node 22, which leaves security support in April 2027. Node 26 becomes LTS in October 2026 and is supported until April 2029.

NodeSource serves 26.7.0 for the `dotnet/sdk:10.0` base the build stage uses, and pnpm 11.18.0 installs and runs `pnpm setup` under it. The image build in CI covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)